### PR TITLE
Compensate for change to saveLayer

### DIFF
--- a/display_list/display_list_dispatcher.cc
+++ b/display_list/display_list_dispatcher.cc
@@ -137,8 +137,10 @@ static std::optional<Rect> ToRect(const SkRect* rect) {
 
 // |flutter::Dispatcher|
 void DisplayListDispatcher::saveLayer(const SkRect* bounds,
-                                      bool restore_with_paint) {
-  canvas_.SaveLayer(restore_with_paint ? paint_ : Paint{}, ToRect(bounds));
+                                      const flutter::SaveLayerOptions options) {
+  canvas_.SaveLayer(
+    options.renders_with_attributes() ? paint_ : Paint{},
+    ToRect(bounds));
 }
 
 // |flutter::Dispatcher|

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -75,7 +75,8 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void save() override;
 
   // |flutter::Dispatcher|
-  void saveLayer(const SkRect* bounds, bool restore_with_paint) override;
+  void saveLayer(const SkRect* bounds,
+                 const flutter::SaveLayerOptions options) override;
 
   // |flutter::Dispatcher|
   void restore() override;


### PR DESCRIPTION
Trying to compensate for the change to `saveLayer()` in https://github.com/flutter/engine/pull/30957.