### PR TITLE
Adds a GN flag for playgrounds

### DIFF
--- a/aiks/aiks_playground.cc
+++ b/aiks/aiks_playground.cc
@@ -13,6 +13,10 @@ AiksPlayground::AiksPlayground() = default;
 AiksPlayground::~AiksPlayground() = default;
 
 bool AiksPlayground::OpenPlaygroundHere(const Picture& picture) {
+  if (!Playground::is_enabled()) {
+    return true;
+  }
+
   AiksContext renderer(GetContext());
 
   if (!renderer.IsValid()) {

--- a/entity/entity_playground.cc
+++ b/entity/entity_playground.cc
@@ -13,6 +13,10 @@ EntityPlayground::EntityPlayground() = default;
 EntityPlayground::~EntityPlayground() = default;
 
 bool EntityPlayground::OpenPlaygroundHere(Entity entity) {
+  if (!Playground::is_enabled()) {
+    return true;
+  }
+
   ContentContext context_context(GetContext());
   if (!context_context.IsValid()) {
     return false;

--- a/playground/BUILD.gn
+++ b/playground/BUILD.gn
@@ -21,10 +21,18 @@ impeller_component("playground") {
     "//third_party/glfw",
   ]
 
+  public_configs = [ ":playground_config" ]
+
   if (is_mac) {
     frameworks = [
       "AppKit.framework",
       "QuartzCore.framework",
     ]
+  }
+}
+
+config("playground_config") {
+  if (impeller_enable_playground) {
+    defines = [ "IMPELLER_ENABLE_PLAYGROUND" ]
   }
 }

--- a/playground/playground.h
+++ b/playground/playground.h
@@ -19,6 +19,8 @@ class Playground : public ::testing::Test {
 
   ~Playground();
 
+  static constexpr bool is_enabled() { return is_enabled_; }
+
   Point GetCursorPosition() const;
 
   ISize GetWindowSize() const;
@@ -31,6 +33,12 @@ class Playground : public ::testing::Test {
       const char* fixture_name) const;
 
  private:
+#if IMPELLER_ENABLE_PLAYGROUND
+  static const bool is_enabled_ = true;
+#else
+  static const bool is_enabled_ = false;
+#endif  // IMPELLER_ENABLE_PLAYGROUND
+
   Renderer renderer_;
   Point cursor_position_;
   ISize window_size_ = ISize{1024, 768};

--- a/playground/playground.mm
+++ b/playground/playground.mm
@@ -81,6 +81,10 @@ void Playground::SetCursorPosition(Point pos) {
 }
 
 bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
+  if (!is_enabled()) {
+    return true;
+  }
+
   if (!render_callback) {
     return true;
   }

--- a/tools/impeller.gni
+++ b/tools/impeller.gni
@@ -5,6 +5,11 @@
 import("//build/compiled_action.gni")
 import("//flutter/common/config.gni")
 
+declare_args() {
+  # Whether playgrounds are enabled for unit tests.
+  impeller_enable_playground = false
+}
+
 template("impeller_component") {
   source_set(target_name) {
     forward_variables_from(invoker, "*")


### PR DESCRIPTION
Adds a GN build-time flag for enabling the unit test playgrounds. Goes along with https://github.com/flutter/engine/pull/31280, which adds the flag to `flutter/tools/gn`.