### PR TITLE
Add viewport and scissor support

### DIFF
--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -335,5 +335,37 @@ TEST(GeometryTest, RectContainsPoint) {
   }
 }
 
+TEST(GeometryTest, RectContainsRect) {
+  {
+    Rect a(100, 100, 100, 100);
+    ASSERT_TRUE(a.Contains(a));
+  }
+  {
+    Rect a(100, 100, 100, 100);
+    Rect b(0, 0, 0, 0);
+    ASSERT_FALSE(a.Contains(b));
+  }
+  {
+    Rect a(100, 100, 100, 100);
+    Rect b(150, 150, 20, 20);
+    ASSERT_TRUE(a.Contains(b));
+  }
+  {
+    Rect a(100, 100, 100, 100);
+    Rect b(150, 150, 100, 100);
+    ASSERT_FALSE(a.Contains(b));
+  }
+  {
+    Rect a(100, 100, 100, 100);
+    Rect b(50, 50, 100, 100);
+    ASSERT_FALSE(a.Contains(b));
+  }
+  {
+    Rect a(100, 100, 100, 100);
+    Rect b(0, 0, 300, 300);
+    ASSERT_FALSE(a.Contains(b));
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -84,6 +84,10 @@ struct TRect {
            p.y < origin.y + size.height;
   }
 
+  constexpr bool Contains(const TRect& o) const {
+    return Union(o).size == size;
+  }
+
   constexpr bool IsZero() const { return size.IsZero(); }
 
   constexpr bool IsEmpty() const { return size.IsEmpty(); }

--- a/renderer/command.h
+++ b/renderer/command.h
@@ -6,10 +6,12 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
+#include "impeller/geometry/rect.h"
 #include "impeller/renderer/buffer_view.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/pipeline.h"
@@ -69,6 +71,19 @@ struct Command {
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
   WindingOrder winding = WindingOrder::kClockwise;
   uint32_t stencil_reference = 0u;
+  //----------------------------------------------------------------------------
+  /// The viewport coordinates that the rasterizer linearly maps normalized
+  /// device coordinates to.
+  /// If unset, the viewport is the size of the render target with a zero
+  /// origin, znear=0, and zfar=1.
+  ///
+  std::optional<Viewport> viewport;
+  //----------------------------------------------------------------------------
+  /// The scissor rect to use for clipping writes to the render target. The
+  /// scissor rect must lie entirely within the render target.
+  /// If unset, no scissor is applied.
+  ///
+  std::optional<IRect> scissor;
 
   bool BindVertices(const VertexBuffer& buffer);
 

--- a/renderer/formats.h
+++ b/renderer/formats.h
@@ -11,6 +11,8 @@
 
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/macros.h"
+#include "impeller/geometry/rect.h"
+#include "impeller/geometry/scalar.h"
 #include "impeller/geometry/color.h"
 
 namespace impeller {
@@ -147,6 +149,12 @@ enum class PrimitiveType {
   kPoint,
   // Triangle fans are implementation dependent and need extra extensions
   // checks. Hence, they are not supported here.
+};
+
+struct Viewport {
+  Rect rect;
+  Scalar znear = 0.0f;
+  Scalar zfar = 1.0f;
 };
 
 enum class MinMagFilter {


### PR DESCRIPTION
Used optionals for these because the default behavior with their absence will be similar across graphics backends.
Most modern APIs support multiple viewports and multiple scissor rects (not sure about driver coverage though), but GLES3 does not.

I think it's reasonable to include these as command params against all rendering backends. In Vulkan, we'd flip these on as [dynamic state](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDynamicState.html) in pipelines and then set them with commands.

Used these in an [imgui backend](https://github.com/bdero/impeller/blob/3ac316755d016f7ea25c8e4504d5b5a151dd226a/bdero_pbr/imgui/imgui_impl_impeller.cc#L184-L188) that targets impeller 🙂 :

https://user-images.githubusercontent.com/919017/154174965-91656bd4-3bdf-408c-8643-94aaf117f362.mov

