### PR TITLE
Fix Rect::Contains bugs

### DIFF
--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -310,5 +310,30 @@ TEST(GeometryTest, RectIntersection) {
   }
 }
 
+TEST(GeometryTest, RectContainsPoint) {
+  {
+    // Origin is inclusive
+    Rect r(100, 100, 100, 100);
+    Point p(100, 100);
+    ASSERT_TRUE(r.Contains(p));
+  }
+  {
+    // Size is exclusive
+    Rect r(100, 100, 100, 100);
+    Point p(200, 200);
+    ASSERT_FALSE(r.Contains(p));
+  }
+  {
+    Rect r(100, 100, 100, 100);
+    Point p(99, 99);
+    ASSERT_FALSE(r.Contains(p));
+  }
+  {
+    Rect r(100, 100, 100, 100);
+    Point p(199, 199);
+    ASSERT_TRUE(r.Contains(p));
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -80,8 +80,8 @@ struct TRect {
   }
 
   constexpr bool Contains(const TPoint<Type>& p) const {
-    return p.x >= origin.x && p.x <= size.width && p.y >= origin.y &&
-           p.y <= size.height;
+    return p.x >= origin.x && p.x < origin.x + size.width && p.y >= origin.y &&
+           p.y < origin.y + size.height;
   }
 
   constexpr bool IsZero() const { return size.IsZero(); }


### PR DESCRIPTION
Fix `Rect::Compare` to use origin + size for bottom and right compare.