### PR TITLE
Support 16bit index buffers

### DIFF
--- a/renderer/backend/metal/formats_mtl.h
+++ b/renderer/backend/metal/formats_mtl.h
@@ -107,6 +107,15 @@ constexpr MTLPrimitiveType ToMTLPrimitiveType(PrimitiveType type) {
   return MTLPrimitiveTypePoint;
 }
 
+constexpr MTLIndexType ToMTLIndexType(IndexType type) {
+  switch (type) {
+    case IndexType::k16bit:
+      return MTLIndexTypeUInt16;
+    default:
+      return MTLIndexTypeUInt32;
+  }
+}
+
 constexpr MTLBlendOperation ToMTLBlendOperation(BlendOperation type) {
   switch (type) {
     case BlendOperation::kAdd:

--- a/renderer/backend/metal/render_pass_mtl.mm
+++ b/renderer/backend/metal/render_pass_mtl.mm
@@ -13,6 +13,7 @@
 #include "impeller/renderer/backend/metal/pipeline_mtl.h"
 #include "impeller/renderer/backend/metal/sampler_mtl.h"
 #include "impeller/renderer/backend/metal/texture_mtl.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/host_buffer.h"
 #include "impeller/renderer/shader_types.h"
 
@@ -434,6 +435,17 @@ bool RenderPassMTL::EncodeCommands(Allocator& allocator,
                               ShaderStage::kFragment)) {
       return false;
     }
+    MTLIndexType index_type;
+    switch (command.index_type) {
+      case IndexType::k16bit:
+        index_type = MTLIndexTypeUInt16;
+        break;
+      case IndexType::k32bit:
+        index_type = MTLIndexTypeUInt32;
+        break;
+      case IndexType::kUnknown:
+        return false;
+    }
     auto index_buffer = command.index_buffer.buffer;
     if (!index_buffer) {
       return false;
@@ -452,7 +464,7 @@ bool RenderPassMTL::EncodeCommands(Allocator& allocator,
     // Returns void. All error checking must be done by this point.
     [encoder drawIndexedPrimitives:ToMTLPrimitiveType(command.primitive_type)
                         indexCount:command.index_count
-                         indexType:MTLIndexTypeUInt32
+                         indexType:index_type
                        indexBuffer:mtl_index_buffer
                  indexBufferOffset:command.index_buffer.range.offset
                      instanceCount:1u

--- a/renderer/backend/metal/render_pass_mtl.mm
+++ b/renderer/backend/metal/render_pass_mtl.mm
@@ -435,16 +435,8 @@ bool RenderPassMTL::EncodeCommands(Allocator& allocator,
                               ShaderStage::kFragment)) {
       return false;
     }
-    MTLIndexType index_type;
-    switch (command.index_type) {
-      case IndexType::k16bit:
-        index_type = MTLIndexTypeUInt16;
-        break;
-      case IndexType::k32bit:
-        index_type = MTLIndexTypeUInt32;
-        break;
-      case IndexType::kUnknown:
-        return false;
+    if (command.index_type == IndexType::kUnknown) {
+      return false;
     }
     auto index_buffer = command.index_buffer.buffer;
     if (!index_buffer) {
@@ -464,7 +456,7 @@ bool RenderPassMTL::EncodeCommands(Allocator& allocator,
     // Returns void. All error checking must be done by this point.
     [encoder drawIndexedPrimitives:ToMTLPrimitiveType(command.primitive_type)
                         indexCount:command.index_count
-                         indexType:index_type
+                         indexType:ToMTLIndexType(command.index_type)
                        indexBuffer:mtl_index_buffer
                  indexBufferOffset:command.index_buffer.range.offset
                      instanceCount:1u

--- a/renderer/command.cc
+++ b/renderer/command.cc
@@ -4,15 +4,21 @@
 
 #include "impeller/renderer/command.h"
 
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/vertex_descriptor.h"
 
 namespace impeller {
 
 bool Command::BindVertices(const VertexBuffer& buffer) {
+  if (index_type == IndexType::kUnknown) {
+    return false;
+  }
+
   vertex_bindings.buffers[VertexDescriptor::kReservedVertexBufferIndex] =
       buffer.vertex_buffer;
   index_buffer = buffer.index_buffer;
   index_count = buffer.index_count;
+  index_type = buffer.index_type;
   return true;
 }
 

--- a/renderer/command.h
+++ b/renderer/command.h
@@ -64,6 +64,7 @@ struct Command {
   ///
   BufferView index_buffer;
   size_t index_count = 0u;
+  IndexType index_type = IndexType::kUnknown;
   std::string label;
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
   WindingOrder winding = WindingOrder::kClockwise;

--- a/renderer/formats.h
+++ b/renderer/formats.h
@@ -133,6 +133,12 @@ enum class WindingOrder {
   kCounterClockwise,
 };
 
+enum class IndexType {
+  kUnknown,
+  k16bit,
+  k32bit,
+};
+
 enum class PrimitiveType {
   kTriangle,
   kTriangleStrip,

--- a/renderer/vertex_buffer.h
+++ b/renderer/vertex_buffer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "impeller/renderer/buffer_view.h"
+#include "impeller/renderer/formats.h"
 
 namespace impeller {
 
@@ -12,6 +13,7 @@ struct VertexBuffer {
   BufferView vertex_buffer;
   BufferView index_buffer;
   size_t index_count = 0u;
+  IndexType index_type = IndexType::kUnknown;
 
   constexpr operator bool() const {
     return static_cast<bool>(vertex_buffer) && static_cast<bool>(index_buffer);

--- a/renderer/vertex_buffer_builder.h
+++ b/renderer/vertex_buffer_builder.h
@@ -29,6 +29,16 @@ class VertexBufferBuilder {
 
   ~VertexBufferBuilder() = default;
 
+  constexpr impeller::IndexType GetIndexType() const {
+    if constexpr (sizeof(IndexType) == 2) {
+      return impeller::IndexType::k16bit;
+    } else if (sizeof(IndexType) == 4) {
+      return impeller::IndexType::k32bit;
+    } else {
+      return impeller::IndexType::kUnknown;
+    }
+  }
+
   void SetLabel(std::string label) { label_ = std::move(label); }
 
   void Reserve(size_t count) { return vertices_.reserve(count); }
@@ -56,6 +66,7 @@ class VertexBufferBuilder {
     buffer.vertex_buffer = CreateVertexBufferView(host_buffer);
     buffer.index_buffer = CreateIndexBufferView(host_buffer);
     buffer.index_count = GetIndexCount();
+    buffer.index_type = GetIndexType();
     return buffer;
   };
 
@@ -65,6 +76,7 @@ class VertexBufferBuilder {
     buffer.vertex_buffer = CreateVertexBufferView(device_allocator);
     buffer.index_buffer = CreateIndexBufferView(device_allocator);
     buffer.index_count = GetIndexCount();
+    buffer.index_type = GetIndexType();
     return buffer;
   };
 


### PR DESCRIPTION
Draw calls spanning a >64k vertex window are the rare case in most renderers. In the entities/displaylist renderer we'll probably prefer to split uncommon large draws into multiple calls in favor of the large index buffer memory/bandwidth savings on mobile.
Splitting big draw calls is trivial with the presence of the `baseVertex` param in Metal or `glDrawElementsBaseVertex` in GLES (will add in follow-up).