### PR TITLE
Support nested clips & clip state restoration

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -106,6 +106,18 @@ TEST_F(AiksTest, CanRenderClips) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_F(AiksTest, CanRenderNestedClips) {
+  Canvas canvas;
+  Paint paint;
+  paint.color = Color::Fuchsia();
+  canvas.Save();
+  canvas.ClipPath(PathBuilder{}.AddCircle({200, 400}, 300).TakePath());
+  canvas.Restore();
+  canvas.ClipPath(PathBuilder{}.AddCircle({600, 400}, 300).TakePath());
+  canvas.DrawRect(Rect::MakeXYWH(200, 200, 400, 400), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_F(AiksTest, CanSaveLayerStandalone) {
   Canvas canvas;
 

--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -114,6 +114,7 @@ TEST_F(AiksTest, CanRenderNestedClips) {
   canvas.ClipPath(PathBuilder{}.AddCircle({200, 400}, 300).TakePath());
   canvas.Restore();
   canvas.ClipPath(PathBuilder{}.AddCircle({600, 400}, 300).TakePath());
+  canvas.ClipPath(PathBuilder{}.AddCircle({400, 600}, 300).TakePath());
   canvas.DrawRect(Rect::MakeXYWH(200, 200, 400, 400), paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -46,8 +46,12 @@ bool Canvas::Restore() {
     FML_DCHECK(current_pass_);
   }
 
+  bool contains_clips = xformation_stack_.back().contains_clips;
   xformation_stack_.pop_back();
-  RestoreClip();
+
+  if (contains_clips) {
+    RestoreClip();
+  }
 
   return true;
 }
@@ -142,6 +146,7 @@ void Canvas::ClipPath(Path path) {
   GetCurrentPass().AddEntity(std::move(entity));
 
   ++xformation_stack_.back().stencil_depth;
+  xformation_stack_.back().contains_clips = true;
 }
 
 void Canvas::RestoreClip() {

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -152,6 +152,8 @@ void Canvas::ClipPath(Path path) {
 void Canvas::RestoreClip() {
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
+  // This path is empty because ClipRestoreContents just generates a quad that
+  // takes up the full render target.
   entity.SetPath({});
   entity.SetContents(std::make_shared<ClipRestoreContents>());
   entity.SetStencilDepth(GetStencilDepth());

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -47,7 +47,7 @@ bool Canvas::Restore() {
   }
 
   xformation_stack_.pop_back();
-  ReverseClipPaths();
+  RestoreClip();
 
   return true;
 }
@@ -144,11 +144,11 @@ void Canvas::ClipPath(Path path) {
   ++xformation_stack_.back().stencil_depth;
 }
 
-void Canvas::ReverseClipPaths() {
+void Canvas::RestoreClip() {
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetPath({});
-  entity.SetContents(std::make_shared<InverseClipContents>());
+  entity.SetContents(std::make_shared<ClipRestoreContents>());
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetAddsToCoverage(false);
 

--- a/aiks/canvas.h
+++ b/aiks/canvas.h
@@ -87,11 +87,11 @@ class Canvas {
 
   EntityPass& GetCurrentPass();
 
-  void IncrementStencilDepth();
-
   size_t GetStencilDepth() const;
 
   void Save(bool create_subpass);
+
+  void ReverseClipPaths();
 
   FML_DISALLOW_COPY_AND_ASSIGN(Canvas);
 };

--- a/aiks/canvas.h
+++ b/aiks/canvas.h
@@ -91,7 +91,7 @@ class Canvas {
 
   void Save(bool create_subpass);
 
-  void ReverseClipPaths();
+  void RestoreClip();
 
   FML_DISALLOW_COPY_AND_ASSIGN(Canvas);
 };

--- a/entity/content_context.cc
+++ b/entity/content_context.cc
@@ -23,6 +23,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
       std::make_unique<SolidStrokePipeline>(*context_);
 
   // Pipelines that are variants of the base pipelines with custom descriptors.
+  // TODO(98684): Rework this API to allow fetching the descriptor without
+  //              waiting for the pipeline to build.
   if (auto solid_fill_pipeline = solid_fill_pipelines_[{}]->WaitAndGet()) {
     // Clip pipeline.
     {

--- a/entity/content_context.cc
+++ b/entity/content_context.cc
@@ -29,7 +29,7 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
     // Write to the stencil buffer.
     StencilAttachmentDescriptor stencil0;
     stencil0.stencil_compare = CompareFunction::kGreaterEqual;
-    stencil0.depth_stencil_pass = StencilOperation::kSetToReferenceValue;
+    stencil0.depth_stencil_pass = StencilOperation::kIncrementClamp;
     clip_pipeline_descriptor.SetStencilAttachmentDescriptors(stencil0);
     // Disable write to all color attachments.
     auto color_attachments =
@@ -40,7 +40,13 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
     }
     clip_pipeline_descriptor.SetColorAttachmentDescriptors(
         std::move(color_attachments));
-    clip_pipelines_[{}] = std::make_unique<ClipPipeline>(
+    clip_pipelines_[{}] =
+        std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
+
+    // Inverse clip pipeline.
+    stencil0.depth_stencil_pass = StencilOperation::kDecrementClamp;
+    clip_pipeline_descriptor.SetStencilAttachmentDescriptors(stencil0);
+    inverse_clip_pipelines_[{}] = std::make_unique<ClipPipeline>(
         *context_, std::move(clip_pipeline_descriptor));
   } else {
     return;

--- a/entity/content_context.h
+++ b/entity/content_context.h
@@ -78,7 +78,7 @@ class ContentContext {
   }
 
   std::shared_ptr<Pipeline> GetClipRestorePipeline(Options opts) const {
-    return GetPipeline(inverse_clip_pipelines_, opts);
+    return GetPipeline(clip_restoration_pipelines_, opts);
   }
 
   std::shared_ptr<Context> GetContext() const;
@@ -98,7 +98,7 @@ class ContentContext {
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<SolidStrokePipeline> solid_stroke_pipelines_;
   mutable Variants<ClipPipeline> clip_pipelines_;
-  mutable Variants<ClipPipeline> inverse_clip_pipelines_;
+  mutable Variants<ClipPipeline> clip_restoration_pipelines_;
 
   static void ApplyOptionsToDescriptor(PipelineDescriptor& desc,
                                        const Options& options) {

--- a/entity/content_context.h
+++ b/entity/content_context.h
@@ -77,6 +77,10 @@ class ContentContext {
     return GetPipeline(clip_pipelines_, opts);
   }
 
+  std::shared_ptr<Pipeline> GetInverseClipPipeline(Options opts) const {
+    return GetPipeline(inverse_clip_pipelines_, opts);
+  }
+
   std::shared_ptr<Context> GetContext() const;
 
  private:
@@ -94,6 +98,7 @@ class ContentContext {
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<SolidStrokePipeline> solid_stroke_pipelines_;
   mutable Variants<ClipPipeline> clip_pipelines_;
+  mutable Variants<ClipPipeline> inverse_clip_pipelines_;
 
   static void ApplyOptionsToDescriptor(PipelineDescriptor& desc,
                                        const Options& options) {

--- a/entity/content_context.h
+++ b/entity/content_context.h
@@ -77,7 +77,7 @@ class ContentContext {
     return GetPipeline(clip_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline> GetInverseClipPipeline(Options opts) const {
+  std::shared_ptr<Pipeline> GetClipRestorePipeline(Options opts) const {
     return GetPipeline(inverse_clip_pipelines_, opts);
   }
 

--- a/entity/contents.cc
+++ b/entity/contents.cc
@@ -378,20 +378,14 @@ ClipContents::ClipContents() = default;
 
 ClipContents::~ClipContents() = default;
 
-void ClipContents::SetInverse(bool inverse) {
-  inverse_ = inverse;
-}
-
 bool ClipContents::Render(const ContentContext& renderer,
                           const Entity& entity,
                           RenderPass& pass) const {
   using VS = ClipPipeline::VertexShader;
 
   Command cmd;
-  cmd.label = inverse_ ? "Inverse Clip" : "Clip";
-  cmd.pipeline = inverse_
-                     ? renderer.GetClipRestorePipeline(OptionsFromPass(pass))
-                     : renderer.GetClipPipeline(OptionsFromPass(pass));
+  cmd.label = "Clip";
+  cmd.pipeline = renderer.GetClipPipeline(OptionsFromPass(pass));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(
       CreateSolidFillVertices(entity.GetPath(), pass.GetTransientsBuffer()));
@@ -421,7 +415,7 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
   using VS = ClipPipeline::VertexShader;
 
   Command cmd;
-  cmd.label = "Inverse Clip";
+  cmd.label = "Clip Restore";
   cmd.pipeline = renderer.GetClipRestorePipeline(OptionsFromPass(pass));
   cmd.stencil_reference = entity.GetStencilDepth();
 

--- a/entity/contents.cc
+++ b/entity/contents.cc
@@ -15,8 +15,8 @@
 #include "impeller/renderer/sampler_library.h"
 #include "impeller/renderer/surface.h"
 #include "impeller/renderer/tessellator.h"
-#include "impeller/renderer/vertex_buffer_builder.h"
 #include "impeller/renderer/vertex_buffer.h"
+#include "impeller/renderer/vertex_buffer_builder.h"
 
 namespace impeller {
 
@@ -390,7 +390,7 @@ bool ClipContents::Render(const ContentContext& renderer,
   Command cmd;
   cmd.label = inverse_ ? "Inverse Clip" : "Clip";
   cmd.pipeline = inverse_
-                     ? renderer.GetInverseClipPipeline(OptionsFromPass(pass))
+                     ? renderer.GetClipRestorePipeline(OptionsFromPass(pass))
                      : renderer.GetClipPipeline(OptionsFromPass(pass));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(
@@ -408,21 +408,21 @@ bool ClipContents::Render(const ContentContext& renderer,
 }
 
 /*******************************************************************************
- ******* InverseClipContents
+ ******* ClipRestoreContents
  ******************************************************************************/
 
-InverseClipContents::InverseClipContents() = default;
+ClipRestoreContents::ClipRestoreContents() = default;
 
-InverseClipContents::~InverseClipContents() = default;
+ClipRestoreContents::~ClipRestoreContents() = default;
 
-bool InverseClipContents::Render(const ContentContext& renderer,
+bool ClipRestoreContents::Render(const ContentContext& renderer,
                                  const Entity& entity,
                                  RenderPass& pass) const {
   using VS = ClipPipeline::VertexShader;
 
   Command cmd;
   cmd.label = "Inverse Clip";
-  cmd.pipeline = renderer.GetInverseClipPipeline(OptionsFromPass(pass));
+  cmd.pipeline = renderer.GetClipRestorePipeline(OptionsFromPass(pass));
   cmd.stencil_reference = entity.GetStencilDepth();
 
   // Create a rect that covers the whole render target.

--- a/entity/contents.cc
+++ b/entity/contents.cc
@@ -377,15 +377,21 @@ ClipContents::ClipContents() = default;
 
 ClipContents::~ClipContents() = default;
 
+void ClipContents::SetInverse(bool inverse) {
+  inverse_ = inverse;
+}
+
 bool ClipContents::Render(const ContentContext& renderer,
                           const Entity& entity,
                           RenderPass& pass) const {
   using VS = ClipPipeline::VertexShader;
 
   Command cmd;
-  cmd.label = "Clip";
-  cmd.pipeline = renderer.GetClipPipeline(OptionsFromPass(pass));
-  cmd.stencil_reference = entity.GetStencilDepth() + 1u;
+  cmd.label = inverse_ ? "Inverse Clip" : "Clip";
+  cmd.pipeline = inverse_
+                     ? renderer.GetInverseClipPipeline(OptionsFromPass(pass))
+                     : renderer.GetClipPipeline(OptionsFromPass(pass));
+  cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(
       CreateSolidFillVertices(entity.GetPath(), pass.GetTransientsBuffer()));
 

--- a/entity/contents.h
+++ b/entity/contents.h
@@ -143,16 +143,12 @@ class ClipContents final : public Contents {
 
   ~ClipContents();
 
-  void SetInverse(bool inverse);
-
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;
 
  private:
-  bool inverse_ = false;
-
   FML_DISALLOW_COPY_AND_ASSIGN(ClipContents);
 };
 
@@ -168,7 +164,6 @@ class ClipRestoreContents final : public Contents {
               RenderPass& pass) const override;
 
  private:
-
   FML_DISALLOW_COPY_AND_ASSIGN(ClipRestoreContents);
 };
 

--- a/entity/contents.h
+++ b/entity/contents.h
@@ -156,4 +156,20 @@ class ClipContents final : public Contents {
   FML_DISALLOW_COPY_AND_ASSIGN(ClipContents);
 };
 
+class InverseClipContents final : public Contents {
+ public:
+  InverseClipContents();
+
+  ~InverseClipContents();
+
+  // |Contents|
+  bool Render(const ContentContext& renderer,
+              const Entity& entity,
+              RenderPass& pass) const override;
+
+ private:
+
+  FML_DISALLOW_COPY_AND_ASSIGN(InverseClipContents);
+};
+
 }  // namespace impeller

--- a/entity/contents.h
+++ b/entity/contents.h
@@ -143,12 +143,16 @@ class ClipContents final : public Contents {
 
   ~ClipContents();
 
+  void SetInverse(bool inverse);
+
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;
 
  private:
+  bool inverse_ = false;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ClipContents);
 };
 

--- a/entity/contents.h
+++ b/entity/contents.h
@@ -156,11 +156,11 @@ class ClipContents final : public Contents {
   FML_DISALLOW_COPY_AND_ASSIGN(ClipContents);
 };
 
-class InverseClipContents final : public Contents {
+class ClipRestoreContents final : public Contents {
  public:
-  InverseClipContents();
+  ClipRestoreContents();
 
-  ~InverseClipContents();
+  ~ClipRestoreContents();
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -169,7 +169,7 @@ class InverseClipContents final : public Contents {
 
  private:
 
-  FML_DISALLOW_COPY_AND_ASSIGN(InverseClipContents);
+  FML_DISALLOW_COPY_AND_ASSIGN(ClipRestoreContents);
 };
 
 }  // namespace impeller

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -73,6 +73,7 @@ struct CanvasStackEntry {
   Matrix xformation;
   size_t stencil_depth = 0u;
   bool is_subpass = false;
+  std::vector<Path> clip_paths;
 };
 
 }  // namespace impeller

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -73,7 +73,6 @@ struct CanvasStackEntry {
   Matrix xformation;
   size_t stencil_depth = 0u;
   bool is_subpass = false;
-  std::vector<Path> clip_paths;
 };
 
 }  // namespace impeller

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -73,6 +73,7 @@ struct CanvasStackEntry {
   Matrix xformation;
   size_t stencil_depth = 0u;
   bool is_subpass = false;
+  bool contains_clips = false;
 };
 
 }  // namespace impeller

--- a/renderer/pipeline_builder.h
+++ b/renderer/pipeline_builder.h
@@ -8,6 +8,7 @@
 #include "flutter/fml/macros.h"
 #include "impeller/base/base.h"
 #include "impeller/renderer/context.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/shader_library.h"
 #include "impeller/renderer/vertex_descriptor.h"

--- a/renderer/pipeline_builder.h
+++ b/renderer/pipeline_builder.h
@@ -108,7 +108,7 @@ struct PipelineBuilder {
     // Setup default stencil buffer descriptions.
     {
       StencilAttachmentDescriptor stencil0;
-      stencil0.stencil_compare = CompareFunction::kLessEqual;
+      stencil0.stencil_compare = CompareFunction::kEqual;
       desc.SetStencilAttachmentDescriptors(stencil0);
       desc.SetStencilPixelFormat(PixelFormat::kDefaultStencil);
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98631.

Restoration works with a single draw call:
- When clip paths are added, they increase the stencil height only if the stencil matches the current depth. So higher depths are always a subset of lower depths.
- When popping the canvas stack, an entity is appended to run a draw call which max bounds the stencil to the previous depth.