### PR TITLE
Fix breaking vertex binding bug

### DIFF
--- a/renderer/command.cc
+++ b/renderer/command.cc
@@ -4,13 +4,15 @@
 
 #include "impeller/renderer/command.h"
 
+#include "impeller/base/validation.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/vertex_descriptor.h"
 
 namespace impeller {
 
 bool Command::BindVertices(const VertexBuffer& buffer) {
-  if (index_type == IndexType::kUnknown) {
+  if (buffer.index_type == IndexType::kUnknown) {
+    VALIDATION_LOG << "Cannot bind vertex buffer with an unknown index type.";
     return false;
   }
 


### PR DESCRIPTION
Fixes a bug introduced in c535672 which broke a bunch of tests (this slipped under the radar for a while likely because I ran the wrong test filter and all my other PRs are based before 78bc2a02 because https://github.com/flutter/engine/pull/31491 wasn't merged yet).