### PR TITLE
Add base vertex to command

### DIFF
--- a/renderer/backend/metal/render_pass_mtl.mm
+++ b/renderer/backend/metal/render_pass_mtl.mm
@@ -482,7 +482,7 @@ bool RenderPassMTL::EncodeCommands(Allocator& allocator,
                        indexBuffer:mtl_index_buffer
                  indexBufferOffset:command.index_buffer.range.offset
                      instanceCount:1u
-                        baseVertex:0u
+                        baseVertex:command.base_vertex
                       baseInstance:0u];
   }
   return true;

--- a/renderer/command.h
+++ b/renderer/command.h
@@ -73,6 +73,10 @@ struct Command {
   CullMode cull_mode = CullMode::kNone;
   uint32_t stencil_reference = 0u;
   //----------------------------------------------------------------------------
+  /// The offset used when indexing into the vertex buffer.
+  ///
+  uint64_t base_vertex = 0u;
+  //----------------------------------------------------------------------------
   /// The viewport coordinates that the rasterizer linearly maps normalized
   /// device coordinates to.
   /// If unset, the viewport is the size of the render target with a zero


### PR DESCRIPTION
More like _based_ vertex, amirite?

Universally supported and useful when packing multiple meshes into a vertex buffer. Will use this in the imgui backend with 16 bit index buffers.