### PR TITLE
Fix index size check to respect 16 bit buffers

### DIFF
--- a/renderer/backend/metal/render_pass_mtl.mm
+++ b/renderer/backend/metal/render_pass_mtl.mm
@@ -473,7 +473,8 @@ bool RenderPassMTL::EncodeCommands(Allocator& allocator,
     if (!mtl_index_buffer) {
       return false;
     }
-    FML_DCHECK(command.index_count * sizeof(uint32_t) ==
+    FML_DCHECK(command.index_count *
+                   (command.index_type == IndexType::k16bit ? 2 : 4) ==
                command.index_buffer.range.length);
     // Returns void. All error checking must be done by this point.
     [encoder drawIndexedPrimitives:ToMTLPrimitiveType(command.primitive_type)


### PR DESCRIPTION
Forgot to patch this line in back when I pulled the 16 bit buffers patch out of another branch.