### PR TITLE
Respect TextureContents/Canvas::DrawImageRect source rect

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -59,7 +59,7 @@ TEST_F(AiksTest, CanRenderImage) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_F(AiksTest, DISABLED_CanRenderImageRect) {
+TEST_F(AiksTest, CanRenderImageRect) {
   Canvas canvas;
   Paint paint;
   auto image = std::make_shared<Image>(CreateTextureForFixture("kalimba.jpg"));

--- a/entity/contents.cc
+++ b/entity/contents.cc
@@ -229,11 +229,15 @@ bool TextureContents::Render(const ContentContext& renderer,
     const auto tess_result =
         Tessellator{entity.GetPath().GetFillType()}.Tessellate(
             entity.GetPath().CreatePolyline(),
-            [&vertex_builder, &coverage_rect](Point vtx) {
+            [this, &vertex_builder, &coverage_rect, &texture_size](Point vtx) {
               VS::PerVertexData data;
               data.vertices = vtx;
+              auto coverage_coords =
+                  (vtx - coverage_rect->origin) / coverage_rect->size;
               data.texture_coords =
-                  ((vtx - coverage_rect->origin) / coverage_rect->size);
+                  (source_rect_.origin +
+                   source_rect_.size * coverage_coords) /
+                  texture_size;
               vertex_builder.AppendVertex(data);
             });
     if (!tess_result) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98681.

The only relevant changes are in `entity/contents.cc` and `aiks/aiks_unittests.cc`. This PR depends on/includes the changes in https://github.com/flutter/impeller/pull/21.