### PR TITLE
Add entity playground callback

### DIFF
--- a/entity/entity_playground.cc
+++ b/entity/entity_playground.cc
@@ -17,14 +17,29 @@ bool EntityPlayground::OpenPlaygroundHere(Entity entity) {
     return true;
   }
 
-  ContentContext context_context(GetContext());
-  if (!context_context.IsValid()) {
+  ContentContext content_context(GetContext());
+  if (!content_context.IsValid()) {
     return false;
   }
   Renderer::RenderCallback callback = [&](RenderPass& pass) -> bool {
-    return entity.Render(context_context, pass);
+    return entity.Render(content_context, pass);
   };
   return Playground::OpenPlaygroundHere(callback);
+}
+
+bool EntityPlayground::OpenPlaygroundHere(EntityPlaygroundCallback callback) {
+  if (!Playground::is_enabled()) {
+    return true;
+  }
+
+  ContentContext content_context(GetContext());
+  if (!content_context.IsValid()) {
+    return false;
+  }
+  Renderer::RenderCallback render_callback = [&](RenderPass& pass) -> bool {
+    return callback(content_context, pass);
+  };
+  return Playground::OpenPlaygroundHere(render_callback);
 }
 
 }  // namespace impeller

--- a/entity/entity_playground.h
+++ b/entity/entity_playground.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "flutter/fml/macros.h"
+#include "impeller/entity/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/playground/playground.h"
 
@@ -12,11 +13,16 @@ namespace impeller {
 
 class EntityPlayground : public Playground {
  public:
+  using EntityPlaygroundCallback =
+      std::function<bool(ContentContext& context, RenderPass& pass)>;
+
   EntityPlayground();
 
   ~EntityPlayground();
 
   bool OpenPlaygroundHere(Entity entity);
+
+  bool OpenPlaygroundHere(EntityPlaygroundCallback callback);
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPlayground);


### PR DESCRIPTION
Add a convenience `OpenPlaygroundHere` overload to the entity playground which supplies the `ContentContext` to a render callback.