### PR TITLE
Add immediate mode manipulator widget macros for the playground

### DIFF
--- a/playground/BUILD.gn
+++ b/playground/BUILD.gn
@@ -11,6 +11,8 @@ impeller_component("playground") {
   sources = [
     "playground.h",
     "playground.mm",
+    "widgets.cc",
+    "widgets.h",
   ]
 
   public_deps = [

--- a/playground/widgets.cc
+++ b/playground/widgets.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "widgets.h"
-#include <sstream>
 
 namespace impeller {
 

--- a/playground/widgets.cc
+++ b/playground/widgets.cc
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "widgets.h"
+#include <sstream>
+
+namespace impeller {
+
+//
+
+}  // namespace impeller

--- a/playground/widgets.h
+++ b/playground/widgets.h
@@ -1,0 +1,75 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <tuple>
+
+#include "impeller/base/strings.h"
+#include "impeller/geometry/color.h"
+#include "impeller/geometry/point.h"
+#include "third_party/imgui/imgui.h"
+
+#define IMPELLER_PLAYGROUND_POINT(default_position, radius, color)             \
+  ({                                                                           \
+    static impeller::Point position = default_position;                        \
+    static impeller::Point reset_position = default_position;                  \
+    float radius_ = radius;                                                    \
+    impeller::Color color_ = color;                                            \
+                                                                               \
+    static bool dragging = false;                                              \
+    impeller::Point mouse_pos(ImGui::GetMousePos().x, ImGui::GetMousePos().y); \
+    static impeller::Point prev_mouse_pos = mouse_pos;                         \
+                                                                               \
+    if (ImGui::IsKeyPressed('R')) {                                            \
+      position = reset_position;                                               \
+      dragging = false;                                                        \
+    }                                                                          \
+                                                                               \
+    bool hovering = position.GetDistance(mouse_pos) < radius_ &&               \
+                    position.GetDistance(prev_mouse_pos) < radius_;            \
+    if (!ImGui::IsMouseDown(0)) {                                              \
+      dragging = false;                                                        \
+    } else if (hovering && ImGui::IsMouseClicked(0)) {                         \
+      dragging = true;                                                         \
+    }                                                                          \
+    if (dragging) {                                                            \
+      position += mouse_pos - prev_mouse_pos;                                  \
+    }                                                                          \
+    ImGui::GetBackgroundDrawList()->AddCircleFilled(                           \
+        {position.x, position.y}, radius_,                                     \
+        ImColor(color_.red, color_.green, color_.blue,                         \
+                (hovering || dragging) ? 0.6f : 0.3f));                        \
+    if (hovering || dragging) {                                                \
+      ImGui::GetBackgroundDrawList()->AddText(                                 \
+          {position.x - radius_, position.y + radius_ + 10},                   \
+          ImColor(color_.red, color.green, color.blue, 1.0f),                  \
+          impeller::SPrintF("x:%0.3f y:%0.3f", position.x, position.y)         \
+              .c_str());                                                       \
+    }                                                                          \
+    prev_mouse_pos = mouse_pos;                                                \
+    position;                                                                  \
+  })
+
+#define IMPELLER_PLAYGROUND_LINE(default_position_a, default_position_b, \
+                                 radius, color_a, color_b)               \
+  ({                                                                     \
+    impeller::Point position_a = default_position_a;                     \
+    impeller::Point position_b = default_position_b;                     \
+    float r_ = radius;                                                   \
+    impeller::Color color_a_ = color_a;                                  \
+    impeller::Color color_b_ = color_b;                                  \
+                                                                         \
+    position_a = IMPELLER_PLAYGROUND_POINT(position_a, r_, color_a_);    \
+    position_b = IMPELLER_PLAYGROUND_POINT(position_b, r_, color_b_);    \
+                                                                         \
+    auto dir = (position_b - position_a).Normalize() * r_;               \
+    auto line_a = position_a + dir;                                      \
+    auto line_b = position_b - dir;                                      \
+    ImGui::GetBackgroundDrawList()->AddLine(                             \
+        {line_a.x, line_a.y}, {line_b.x, line_b.y},                      \
+        ImColor(color_b.red, color_b.green, color_b.blue, 0.3f));        \
+                                                                         \
+    std::make_tuple(position_a, position_b);                             \
+  })


### PR DESCRIPTION
Depends on https://github.com/flutter/impeller/pull/26.

Widgets reset when pressing the R key.

Example usage:
```cpp
TEST_F(EntityTest, CubicCurveToTest) {
  EntityPlaygroundCallback callback = [&](ContentContext& context,
                                          RenderPass& pass) -> bool {
    Point a1, a2;
    std::tie(a1, a2) = IMPELLER_PLAYGROUND_LINE(
        Point(222, 130), Point(122, 156), 10, Color::Black(), Color::White());
    Point b1, b2;
    std::tie(b1, b2) = IMPELLER_PLAYGROUND_LINE(
        Point(162, 151), Point(84, 160), 10, Color::Black(), Color::White());

    Path path =
        PathBuilder{}.MoveTo(a1).CubicCurveTo(a2, b2, b1).Close().TakePath();
    Entity entity;
    entity.SetPath(path);
    entity.SetContents(SolidColorContents::Make(Color::Red()));
    return entity.Render(context, pass);
  };

  ASSERT_TRUE(OpenPlaygroundHere(callback));
}
```

https://user-images.githubusercontent.com/919017/155490633-6685e0b1-20f9-4999-94aa-e4bd1211143a.mov



Will replace `BadCubicCurveTest` and `BadCubicCurveAndOverlapTest` with minimal tests once https://github.com/flutter/impeller/pull/27 and https://github.com/flutter/impeller/pull/25 land along with this PR.