### PR TITLE
Support subcontours in strokes, lay groundwork for fills

### DIFF
--- a/compiler/reflector.cc
+++ b/compiler/reflector.cc
@@ -611,6 +611,14 @@ static VertexType VertexTypeFromInputResource(
              type.columns == 1u && type.vecsize == 3u &&
              type.width == sizeof(float) * 8u) {
     result.type_name = "Vector3";
+  } else if (type.basetype == spirv_cross::SPIRType::BaseType::Float &&
+             type.columns == 1u && type.vecsize == 1u &&
+             type.width == sizeof(float) * 8u) {
+    result.type_name = "Scalar";
+  } else if (type.basetype == spirv_cross::SPIRType::BaseType::Int &&
+             type.columns == 1u && type.vecsize == 1u &&
+             type.width == sizeof(int32_t) * 8u) {
+    result.type_name = "int32_t";
   } else {
     // Catch all unknown padding.
     result.type_name = TypeNameWithPaddingOfSize(total_size);

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -25,6 +25,47 @@ TEST_F(EntityTest, CanDrawRect) {
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
 
+TEST_F(EntityTest, ThreeStrokesInOnePath) {
+  Path path = PathBuilder{}
+                  .MoveTo({100, 100})
+                  .LineTo({100, 200})
+                  .MoveTo({100, 300})
+                  .LineTo({100, 400})
+                  .MoveTo({100, 500})
+                  .LineTo({100, 600})
+                  .TakePath();
+
+  Entity entity;
+  entity.SetPath(path);
+  auto contents = std::make_unique<SolidStrokeContents>();
+  contents->SetColor(Color::Red());
+  contents->SetStrokeSize(5.0);
+  entity.SetContents(std::move(contents));
+  ASSERT_TRUE(OpenPlaygroundHere(entity));
+}
+
+TEST_F(EntityTest, TriangleInsideASquare) {
+  Path path = PathBuilder{}
+                  .MoveTo({10, 10})
+                  .LineTo({210, 10})
+                  .LineTo({210, 210})
+                  .LineTo({10, 210})
+                  .Close()
+                  .MoveTo({50, 50})
+                  .LineTo({100, 50})
+                  .LineTo({50, 150})
+                  .Close()
+                  .TakePath();
+
+  Entity entity;
+  entity.SetPath(path);
+  auto contents = std::make_unique<SolidStrokeContents>();
+  contents->SetColor(Color::Red());
+  contents->SetStrokeSize(5.0);
+  entity.SetContents(std::move(contents));
+  ASSERT_TRUE(OpenPlaygroundHere(entity));
+}
+
 TEST_F(EntityTest, DISABLED_BadCubicCurveTest) {
   // Compare with https://fiddle.skia.org/c/b3625f26122c9de7afe7794fcf25ead3
   Path path =
@@ -45,7 +86,6 @@ TEST_F(EntityTest, DISABLED_BadCubicCurveTest) {
   entity.SetPath(path);
   entity.SetContents(SolidColorContents::Make(Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
-
 }
 
 TEST_F(EntityTest, DISABLED_BadCubicCurveAndOverlapTest) {

--- a/entity/shaders/solid_stroke.frag
+++ b/entity/shaders/solid_stroke.frag
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 in vec4 stroke_color;
+in float v_pen_down;
 
 out vec4 frag_color;
 
 void main() {
   frag_color = stroke_color;
+  frag_color.a *= floor(v_pen_down);
 }

--- a/entity/shaders/solid_stroke.vert
+++ b/entity/shaders/solid_stroke.vert
@@ -13,12 +13,15 @@ uniform StrokeInfo {
 
 in vec2 vertex_position;
 in vec2 vertex_normal;
+in float pen_down;
 
 out vec4 stroke_color;
+out float v_pen_down;
 
 void main() {
   // Push one vertex by the half stroke size along the normal vector.
   vec2 offset = vertex_normal * vec2(stroke_info.size * 0.5);
   gl_Position = frame_info.mvp * vec4(vertex_position + offset, 0.0, 1.0);
   stroke_color = stroke_info.color;
+  v_pen_down = pen_down;
 }

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -178,7 +178,8 @@ TEST(GeometryTest, SimplePath) {
         ASSERT_EQ(cubic.cp1, cp1);
         ASSERT_EQ(cubic.cp2, cp2);
         ASSERT_EQ(cubic.p2, p2);
-      });
+      },
+      [](size_t index, const MovePathComponent& move) { ASSERT_TRUE(false); });
 }
 
 TEST(GeometryTest, BoundingBoxCubic) {
@@ -526,7 +527,7 @@ TEST(GeometryTest, RectContainsRect) {
 }
 
 TEST(GeometryTest, CubicPathComponentPolylineDoesNotIncludePointOne) {
-  CubicPathComponent component({10, 10}, {20,35}, {35, 20}, {40, 40});
+  CubicPathComponent component({10, 10}, {20, 35}, {35, 20}, {40, 40});
   SmoothingApproximation approximation;
   auto polyline = component.CreatePolyline(approximation);
   ASSERT_NE(polyline.front().x, 10);

--- a/geometry/path_builder.cc
+++ b/geometry/path_builder.cc
@@ -27,6 +27,7 @@ Path PathBuilder::TakePath(FillType fill) {
 PathBuilder& PathBuilder::MoveTo(Point point, bool relative) {
   current_ = relative ? current_ + point : point;
   subpath_start_ = current_;
+  prototype_.AddMoveComponent(current_);
   return *this;
 }
 
@@ -343,7 +344,10 @@ PathBuilder& PathBuilder::AddPath(const Path& path) {
   auto cubic = [&](size_t index, const CubicPathComponent& c) {
     prototype_.AddCubicComponent(c.p1, c.cp1, c.cp2, c.p2);
   };
-  path.EnumerateComponents(linear, quadratic, cubic);
+  auto move = [&](size_t index, const MovePathComponent& m) {
+    prototype_.AddMoveComponent(m.destination);
+  };
+  path.EnumerateComponents(linear, quadratic, cubic, move);
   return *this;
 }
 

--- a/geometry/path_component.h
+++ b/geometry/path_component.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "impeller/geometry/point.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/geometry/scalar.h"
 
@@ -103,6 +104,18 @@ struct CubicPathComponent {
   bool operator==(const CubicPathComponent& other) const {
     return p1 == other.p1 && cp1 == other.cp1 && cp2 == other.cp2 &&
            p2 == other.p2;
+  }
+};
+
+struct MovePathComponent {
+  Point destination;
+
+  MovePathComponent() {}
+
+  MovePathComponent(Point p) : destination(p) {}
+
+  bool operator==(const MovePathComponent& other) const {
+    return destination == other.destination;
   }
 };
 

--- a/renderer/tessellator.cc
+++ b/renderer/tessellator.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/tessellator.h"
 
+#include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "third_party/libtess2/Include/tesselator.h"
 
@@ -35,7 +36,7 @@ static void DestroyTessellator(TESStesselator* tessellator) {
   }
 }
 
-bool Tessellator::Tessellate(const std::vector<Point>& contours,
+bool Tessellator::Tessellate(const Path::Polyline& contours,
                              VertexCallback callback) const {
   TRACE_EVENT0("impeller", "Tessellator::Tessellate");
   if (!callback) {
@@ -60,11 +61,11 @@ bool Tessellator::Tessellate(const std::vector<Point>& contours,
   /// Feed contour information to the tessellator.
   ///
   static_assert(sizeof(Point) == 2 * sizeof(float));
-  ::tessAddContour(tessellator.get(),  // the C tessellator
-                   kVertexSize,        //
-                   contours.data(),    //
-                   sizeof(Point),      //
-                   contours.size()     //
+  ::tessAddContour(tessellator.get(),       // the C tessellator
+                   kVertexSize,             //
+                   contours.points.data(),  //
+                   sizeof(Point),           //
+                   contours.points.size()   //
   );
 
   //----------------------------------------------------------------------------

--- a/renderer/tessellator.h
+++ b/renderer/tessellator.h
@@ -38,7 +38,7 @@ class Tessellator {
   ///
   /// @return If tessellation was successful.
   ///
-  bool Tessellate(const std::vector<Point>& polyline,
+  bool Tessellate(const Path::Polyline& polyline,
                   VertexCallback callback) const;
 
  private:


### PR DESCRIPTION
Addresses the https://github.com/flutter/flutter/issues/99032#issuecomment-1050192450 part of 99032 by supporting strokes.

Does not fix the weird issues related to winding (?) for the strokes in that test case.

Adds two test cases: a simple case where a stroke has three subcontours (i.e. two MoveTo commands after some drawing), and a slightly more complicated case of drawing multiple segments (square) moving and then more segments (triangle).

The basic algorithm is:

- Introduces a Polyline struct with the original point vector and a set indicating which indices represent a move to point.
- Add an input to the vertex shader about whether the pen is down, and pass it along to the fragment shader. If it is <1, draw a transparent pixel.
- The pen is down whenever we're traversing the polyline to a non-move-to-point. The pen is up when we are traversing to a move-to point.
- Insert vertices that put the pen back down anytime we've added ones that say the pen came up.