### PR TITLE
Fix MoveTo for fills

### DIFF
--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -66,7 +66,7 @@ TEST_F(EntityTest, TriangleInsideASquare) {
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
 
-TEST_F(EntityTest, DISABLED_BadCubicCurveTest) {
+TEST_F(EntityTest, CubicCurveTest) {
   // Compare with https://fiddle.skia.org/c/b3625f26122c9de7afe7794fcf25ead3
   Path path =
       PathBuilder{}
@@ -88,7 +88,7 @@ TEST_F(EntityTest, DISABLED_BadCubicCurveTest) {
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
 
-TEST_F(EntityTest, DISABLED_BadCubicCurveAndOverlapTest) {
+TEST_F(EntityTest, CubicCurveAndOverlapTest) {
   // Compare with https://fiddle.skia.org/c/7a05a3e186c65a8dfb732f68020aae06
   Path path =
       PathBuilder{}

--- a/renderer/tessellator.cc
+++ b/renderer/tessellator.cc
@@ -61,12 +61,24 @@ bool Tessellator::Tessellate(const Path::Polyline& contours,
   /// Feed contour information to the tessellator.
   ///
   static_assert(sizeof(Point) == 2 * sizeof(float));
-  ::tessAddContour(tessellator.get(),       // the C tessellator
-                   kVertexSize,             //
-                   contours.points.data(),  //
-                   sizeof(Point),           //
-                   contours.points.size()   //
-  );
+  size_t start_point_index = 0;
+  for (size_t end_point_index : contours.breaks) {
+    ::tessAddContour(tessellator.get(),  // the C tessellator
+                     kVertexSize,        //
+                     contours.points.data() + start_point_index,  //
+                     sizeof(Point),                               //
+                     end_point_index - start_point_index          //
+    );
+    start_point_index = end_point_index;
+  }
+  if (start_point_index < contours.points.size()) {
+    ::tessAddContour(tessellator.get(),  // the C tessellator
+                     kVertexSize,        //
+                     contours.points.data() + start_point_index,  //
+                     sizeof(Point),                               //
+                     contours.points.size() - start_point_index   //
+    );
+  }
 
   //----------------------------------------------------------------------------
   /// Let's tessellate.

--- a/renderer/tessellator.cc
+++ b/renderer/tessellator.cc
@@ -63,6 +63,7 @@ bool Tessellator::Tessellate(const Path::Polyline& contours,
   static_assert(sizeof(Point) == 2 * sizeof(float));
   size_t start_point_index = 0;
   for (size_t end_point_index : contours.breaks) {
+    end_point_index = std::max(end_point_index, contours.points.size());
     ::tessAddContour(tessellator.get(),  // the C tessellator
                      kVertexSize,        //
                      contours.points.data() + start_point_index,  //

--- a/renderer/tessellator.cc
+++ b/renderer/tessellator.cc
@@ -63,7 +63,7 @@ bool Tessellator::Tessellate(const Path::Polyline& contours,
   static_assert(sizeof(Point) == 2 * sizeof(float));
   size_t start_point_index = 0;
   for (size_t end_point_index : contours.breaks) {
-    end_point_index = std::max(end_point_index, contours.points.size());
+    end_point_index = std::min(end_point_index, contours.points.size());
     ::tessAddContour(tessellator.get(),  // the C tessellator
                      kVertexSize,        //
                      contours.points.data() + start_point_index,  //


### PR DESCRIPTION
Fixes flutter/flutter#99032

Related to https://github.com/flutter/impeller/pull/31

Tessellates individual contours of a polyline separately, to avoid treating `MoveTo` commands as introducing new contours. Removes the `DISABLED` from the test cases, since they now render the same as Skia.