### PR TITLE
Generate correct stroke geometry for connected points & support caps+joins

### DIFF
--- a/entity/contents.h
+++ b/entity/contents.h
@@ -113,6 +113,20 @@ class TextureContents final : public Contents {
 
 class SolidStrokeContents final : public Contents {
  public:
+  enum class Cap {
+    kButt,
+    kRound,
+    kSquare,
+    kLast,
+  };
+
+  enum class Join {
+    kMiter,
+    kRound,
+    kBevel,
+    kLast,
+  };
+
   SolidStrokeContents();
 
   ~SolidStrokeContents() override;
@@ -125,6 +139,18 @@ class SolidStrokeContents final : public Contents {
 
   Scalar GetStrokeSize() const;
 
+  void SetStrokeMiter(Scalar miter);
+
+  Scalar GetStrokeMiter(Scalar miter);
+
+  void SetStrokeCap(Cap cap);
+
+  Cap GetStrokeCap();
+
+  void SetStrokeJoin(Join join);
+
+  Join GetStrokeJoin();
+
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
@@ -133,6 +159,9 @@ class SolidStrokeContents final : public Contents {
  private:
   Color color_;
   Scalar stroke_size_ = 0.0;
+  Scalar miter_ = 0.0;
+  Cap cap_ = Cap::kButt;
+  Join join_ = Join::kMiter;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SolidStrokeContents);
 };

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -7,6 +7,7 @@
 #include "impeller/entity/entity_playground.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/playground/playground.h"
+#include "impeller/playground/widgets.h"
 
 namespace impeller {
 namespace testing {
@@ -45,25 +46,36 @@ TEST_F(EntityTest, ThreeStrokesInOnePath) {
 }
 
 TEST_F(EntityTest, TriangleInsideASquare) {
-  Path path = PathBuilder{}
-                  .MoveTo({10, 10})
-                  .LineTo({210, 10})
-                  .LineTo({210, 210})
-                  .LineTo({10, 210})
-                  .Close()
-                  .MoveTo({50, 50})
-                  .LineTo({100, 50})
-                  .LineTo({50, 150})
-                  .Close()
-                  .TakePath();
+  auto callback = [&](ContentContext& context, RenderPass& pass) {
+    Point a = IMPELLER_PLAYGROUND_POINT(Point(10, 10), 20, Color::White());
+    Point b = IMPELLER_PLAYGROUND_POINT(Point(210, 10), 20, Color::White());
+    Point c = IMPELLER_PLAYGROUND_POINT(Point(210, 210), 20, Color::White());
+    Point d = IMPELLER_PLAYGROUND_POINT(Point(10, 210), 20, Color::White());
+    Point e = IMPELLER_PLAYGROUND_POINT(Point(50, 50), 20, Color::White());
+    Point f = IMPELLER_PLAYGROUND_POINT(Point(100, 50), 20, Color::White());
+    Point g = IMPELLER_PLAYGROUND_POINT(Point(50, 150), 20, Color::White());
+    Path path = PathBuilder{}
+                    .MoveTo(a)
+                    .LineTo(b)
+                    .LineTo(c)
+                    .LineTo(d)
+                    .Close()
+                    .MoveTo(e)
+                    .LineTo(f)
+                    .LineTo(g)
+                    .Close()
+                    .TakePath();
 
-  Entity entity;
-  entity.SetPath(path);
-  auto contents = std::make_unique<SolidStrokeContents>();
-  contents->SetColor(Color::Red());
-  contents->SetStrokeSize(5.0);
-  entity.SetContents(std::move(contents));
-  ASSERT_TRUE(OpenPlaygroundHere(entity));
+    Entity entity;
+    entity.SetPath(path);
+    auto contents = std::make_unique<SolidStrokeContents>();
+    contents->SetColor(Color::Red());
+    contents->SetStrokeSize(20.0);
+    entity.SetContents(std::move(contents));
+
+    return entity.Render(context, pass);
+  };
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 TEST_F(EntityTest, CubicCurveTest) {


### PR DESCRIPTION
This PR is chained on top of https://github.com/flutter/impeller/pull/33 and https://github.com/flutter/impeller/pull/34.
Part of https://github.com/flutter/flutter/issues/99089.

This is a rewrite of the stroke algo that fixes the contour body generation and supports caps+joins. So far I added a simple bevel join, but will add all the rest of the caps+joins in followup(s).
Also, a join isn't being generated for closed paths yet.

https://user-images.githubusercontent.com/919017/155720946-95e0cbfd-d19a-4eea-95cd-c340ac24ad13.mov

