### PR TITLE
Remove break corner cases, simplify strokes, and generate closed path joins

### DIFF
--- a/entity/contents.cc
+++ b/entity/contents.cc
@@ -332,14 +332,12 @@ static VertexBuffer CreateSolidStrokeVertices(const Path& path,
   VS::PerVertexData vtx;
 
   // Normal state.
-  Point direction;
   Point normal;
   Point previous_normal;  // Used for computing joins.
 
-  auto compute_normal = [&polyline, &direction, &normal,
-                         &previous_normal](size_t point_i) {
+  auto compute_normal = [&polyline, &normal, &previous_normal](size_t point_i) {
     previous_normal = normal;
-    direction =
+    Point direction =
         (polyline.points[point_i] - polyline.points[point_i - 1]).Normalize();
     normal = {-direction.y, direction.x};
   };

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -179,7 +179,7 @@ TEST(GeometryTest, SimplePath) {
         ASSERT_EQ(cubic.cp2, cp2);
         ASSERT_EQ(cubic.p2, p2);
       },
-      [](size_t index, const MovePathComponent& move) { ASSERT_TRUE(false); });
+      [](size_t index, const ContourComponent& move) { ASSERT_TRUE(false); });
 }
 
 TEST(GeometryTest, BoundingBoxCubic) {
@@ -638,15 +638,15 @@ TEST(GeometryTest, CubicPathComponentPolylineDoesNotIncludePointOne) {
 
 TEST(GeometryTest, PathCreatePolyLineDoesNotDuplicatePoints) {
   Path path;
-  path.AddMoveComponent({10, 10});
+  path.AddContourComponent({10, 10});
   path.AddLinearComponent({10, 10}, {20, 20});
   path.AddLinearComponent({20, 20}, {30, 30});
-  path.AddMoveComponent({40, 40});
+  path.AddContourComponent({40, 40});
   path.AddLinearComponent({40, 40}, {50, 50});
 
   auto polyline = path.CreatePolyline();
 
-  ASSERT_EQ(polyline.breaks.size(), 2u);
+  ASSERT_EQ(polyline.contours.size(), 2u);
   ASSERT_EQ(polyline.points.size(), 5u);
   ASSERT_EQ(polyline.points[0].x, 10);
   ASSERT_EQ(polyline.points[1].x, 20);

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -727,5 +727,40 @@ TEST(GeometryTest, PathBuilderSetsCorrectContourPropertiesForAddCommands) {
   }
 }
 
+TEST(GeometryTest, PathCreatePolylineGeneratesCorrectContourData) {
+  Path::Polyline polyline = PathBuilder{}
+                                .AddLine({100, 100}, {200, 100})
+                                .MoveTo({100, 200})
+                                .LineTo({150, 250})
+                                .LineTo({200, 200})
+                                .Close()
+                                .TakePath()
+                                .CreatePolyline();
+  ASSERT_EQ(polyline.points.size(), 6u);
+  ASSERT_EQ(polyline.contours.size(), 2u);
+  ASSERT_EQ(polyline.contours[0].is_closed, false);
+  ASSERT_EQ(polyline.contours[0].start_index, 0u);
+  ASSERT_EQ(polyline.contours[1].is_closed, true);
+  ASSERT_EQ(polyline.contours[1].start_index, 2u);
+}
+
+TEST(GeometryTest, PolylineGetContourPointBoundsReturnsCorrectRanges) {
+  Path::Polyline polyline = PathBuilder{}
+                                .AddLine({100, 100}, {200, 100})
+                                .MoveTo({100, 200})
+                                .LineTo({150, 250})
+                                .LineTo({200, 200})
+                                .Close()
+                                .TakePath()
+                                .CreatePolyline();
+  size_t a1, a2, b1, b2;
+  std::tie(a1, a2) = polyline.GetContourPointBounds(0);
+  std::tie(b1, b2) = polyline.GetContourPointBounds(1);
+  ASSERT_EQ(a1, 0u);
+  ASSERT_EQ(a2, 2u);
+  ASSERT_EQ(b1, 2u);
+  ASSERT_EQ(b2, 6u);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -660,5 +660,72 @@ TEST(GeometryTest, PathCreatePolyLineDoesNotDuplicatePoints) {
   ASSERT_EQ(polyline.points[4].x, 50);
 }
 
+TEST(GeometryTest, PathBuilderSetsCorrectContourPropertiesForAddCommands) {
+  // Closed shapes.
+  {
+    Path path = PathBuilder{}.AddCircle({100, 100}, 50).TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, Point(100, 50));
+    ASSERT_TRUE(contour.is_closed);
+  }
+
+  {
+    Path path = PathBuilder{}.AddOval(Rect(100, 100, 100, 100)).TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, Point(150, 100));
+    ASSERT_TRUE(contour.is_closed);
+  }
+
+  {
+    Path path = PathBuilder{}.AddRect(Rect(100, 100, 100, 100)).TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, Point(100, 100));
+    ASSERT_TRUE(contour.is_closed);
+  }
+
+  {
+    Path path =
+        PathBuilder{}.AddRoundedRect(Rect(100, 100, 100, 100), 10).TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, Point(110, 100));
+    ASSERT_TRUE(contour.is_closed);
+  }
+
+  // Open shapes.
+  {
+    Point p(100, 100);
+    Path path = PathBuilder{}.AddLine(p, {200, 100}).TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, p);
+    ASSERT_FALSE(contour.is_closed);
+  }
+
+  {
+    Path path =
+        PathBuilder{}
+            .AddCubicCurve({100, 100}, {100, 50}, {100, 150}, {200, 100})
+            .TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, Point(100, 100));
+    ASSERT_FALSE(contour.is_closed);
+  }
+
+  {
+    Path path = PathBuilder{}
+                    .AddQuadraticCurve({100, 100}, {100, 50}, {200, 100})
+                    .TakePath();
+    ContourComponent contour;
+    path.GetContourComponentAtIndex(0, contour);
+    ASSERT_POINT_NEAR(contour.destination, Point(100, 100));
+    ASSERT_FALSE(contour.is_closed);
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -149,13 +149,13 @@ TEST(GeometryTest, SimplePath) {
       .AddQuadraticComponent({100, 100}, {200, 200}, {300, 300})
       .AddCubicComponent({300, 300}, {400, 400}, {500, 500}, {600, 600});
 
-  ASSERT_EQ(path.GetComponentCount(), 3u);
+  ASSERT_EQ(path.GetComponentCount(), 4u);
 
   path.EnumerateComponents(
       [](size_t index, const LinearPathComponent& linear) {
         Point p1(0, 0);
         Point p2(100, 100);
-        ASSERT_EQ(index, 0u);
+        ASSERT_EQ(index, 1u);
         ASSERT_EQ(linear.p1, p1);
         ASSERT_EQ(linear.p2, p2);
       },
@@ -163,7 +163,7 @@ TEST(GeometryTest, SimplePath) {
         Point p1(100, 100);
         Point cp(200, 200);
         Point p2(300, 300);
-        ASSERT_EQ(index, 1u);
+        ASSERT_EQ(index, 2u);
         ASSERT_EQ(quad.p1, p1);
         ASSERT_EQ(quad.cp, cp);
         ASSERT_EQ(quad.p2, p2);
@@ -173,13 +173,18 @@ TEST(GeometryTest, SimplePath) {
         Point cp1(400, 400);
         Point cp2(500, 500);
         Point p2(600, 600);
-        ASSERT_EQ(index, 2u);
+        ASSERT_EQ(index, 3u);
         ASSERT_EQ(cubic.p1, p1);
         ASSERT_EQ(cubic.cp1, cp1);
         ASSERT_EQ(cubic.cp2, cp2);
         ASSERT_EQ(cubic.p2, p2);
       },
-      [](size_t index, const ContourComponent& move) { ASSERT_TRUE(false); });
+      [](size_t index, const ContourComponent& contour) {
+        Point p1(0, 0);
+        ASSERT_EQ(index, 0u);
+        ASSERT_EQ(contour.destination, p1);
+        ASSERT_FALSE(contour.is_closed);
+      });
 }
 
 TEST(GeometryTest, BoundingBoxCubic) {

--- a/geometry/path.cc
+++ b/geometry/path.cc
@@ -22,7 +22,7 @@ std::tuple<size_t, size_t> Path::Polyline::GetContourPointBounds(
   FML_DCHECK(contour_index < contours.size());
 
   const size_t start_index = contours[contour_index].start_index;
-  const size_t end_index = (contour_index == contours.size())
+  const size_t end_index = (contour_index >= contours.size() - 1)
                                ? points.size()
                                : contours[contour_index + 1].start_index;
   return std::make_tuple(start_index, end_index);
@@ -59,7 +59,8 @@ Path& Path::AddCubicComponent(Point p1, Point cp1, Point cp2, Point p2) {
 }
 
 Path& Path::AddContourComponent(Point destination, bool is_closed) {
-  if (components_.back().type == ComponentType::kContour) {
+  if (components_.size() > 0 &&
+      components_.back().type == ComponentType::kContour) {
     // Never insert contiguous contours.
     contours_.back() = ContourComponent(destination, is_closed);
   } else {
@@ -249,9 +250,9 @@ Path::Polyline Path::CreatePolyline(
           continue;
         }
         const auto& contour = contours_[component.index];
-        collect_points({contour.destination});
         polyline.contours.push_back({.start_index = polyline.points.size(),
                                      .is_closed = contour.is_closed});
+        collect_points({contour.destination});
         break;
     }
   }

--- a/geometry/path.cc
+++ b/geometry/path.cc
@@ -6,11 +6,27 @@
 
 #include <optional>
 
+#include "flutter/fml/logging.h"
+#include "impeller/geometry/path_component.h"
+
 namespace impeller {
 
-Path::Path() = default;
+Path::Path() {
+  AddContourComponent({});
+};
 
 Path::~Path() = default;
+
+std::tuple<size_t, size_t> Path::Polyline::GetContourPointBounds(
+    size_t contour_index) const {
+  FML_DCHECK(contour_index < contours.size());
+
+  const size_t start_index = contours[contour_index].start_index;
+  const size_t end_index = (contour_index == contours.size())
+                               ? points.size()
+                               : contours[contour_index + 1].start_index;
+  return std::make_tuple(start_index, end_index);
+}
 
 size_t Path::GetComponentCount() const {
   return components_.size();
@@ -42,16 +58,26 @@ Path& Path::AddCubicComponent(Point p1, Point cp1, Point cp2, Point p2) {
   return *this;
 }
 
-Path& Path::AddMoveComponent(Point destination) {
-  moves_.emplace_back(destination);
-  components_.emplace_back(ComponentType::kMove, moves_.size() - 1);
+Path& Path::AddContourComponent(Point destination, bool is_closed) {
+  if (components_.back().type == ComponentType::kContour) {
+    // Never insert contiguous contours.
+    contours_.back() = ContourComponent(destination, is_closed);
+  } else {
+    contours_.emplace_back(ContourComponent(destination, is_closed));
+    components_.emplace_back(ComponentType::kContour, contours_.size() - 1);
+  }
   return *this;
 }
 
-void Path::EnumerateComponents(Applier<LinearPathComponent> linear_applier,
-                               Applier<QuadraticPathComponent> quad_applier,
-                               Applier<CubicPathComponent> cubic_applier,
-                               Applier<MovePathComponent> move_applier) const {
+void Path::SetContourClosed(bool is_closed) {
+  contours_.back().is_closed = is_closed;
+}
+
+void Path::EnumerateComponents(
+    Applier<LinearPathComponent> linear_applier,
+    Applier<QuadraticPathComponent> quad_applier,
+    Applier<CubicPathComponent> cubic_applier,
+    Applier<ContourComponent> contour_applier) const {
   size_t currentIndex = 0;
   for (const auto& component : components_) {
     switch (component.type) {
@@ -70,9 +96,9 @@ void Path::EnumerateComponents(Applier<LinearPathComponent> linear_applier,
           cubic_applier(currentIndex, cubics_[component.index]);
         }
         break;
-      case ComponentType::kMove:
-        if (move_applier) {
-          move_applier(currentIndex, moves_[component.index]);
+      case ComponentType::kContour:
+        if (contour_applier) {
+          contour_applier(currentIndex, contours_[component.index]);
         }
         break;
     }
@@ -123,17 +149,17 @@ bool Path::GetCubicComponentAtIndex(size_t index,
   return true;
 }
 
-bool Path::GetMoveComponentAtIndex(size_t index,
-                                   MovePathComponent& move) const {
+bool Path::GetContourComponentAtIndex(size_t index,
+                                      ContourComponent& move) const {
   if (index >= components_.size()) {
     return false;
   }
 
-  if (components_[index].type != ComponentType::kMove) {
+  if (components_[index].type != ComponentType::kContour) {
     return false;
   }
 
-  move = moves_[components_[index].index];
+  move = contours_[components_[index].index];
   return true;
 }
 
@@ -180,38 +206,32 @@ bool Path::UpdateCubicComponentAtIndex(size_t index,
   return true;
 }
 
-bool Path::UpdateMoveComponentAtIndex(size_t index,
-                                      const MovePathComponent& move) {
+bool Path::UpdateContourComponentAtIndex(size_t index,
+                                         const ContourComponent& move) {
   if (index >= components_.size()) {
     return false;
   }
 
-  if (components_[index].type != ComponentType::kMove) {
+  if (components_[index].type != ComponentType::kContour) {
     return false;
   }
 
-  moves_[components_[index].index] = move;
+  contours_[components_[index].index] = move;
   return true;
 }
 
 Path::Polyline Path::CreatePolyline(
     const SmoothingApproximation& approximation) const {
   Polyline polyline;
-  // TODO(99177): Refactor this to have component polyline creation always
-  //              exclude the first point, and append the destination point for
-  //              move components. See issue for details.
-  bool new_contour = true;
-  auto collect_points = [&polyline,
-                         &new_contour](const std::vector<Point>& collection) {
-    size_t offset = new_contour ? 0 : 1;
-    new_contour = false;
-
-    polyline.points.reserve(polyline.points.size() + collection.size() -
-                            offset);
-    polyline.points.insert(polyline.points.end(), collection.begin() + offset,
+  auto collect_points = [&polyline](const std::vector<Point>& collection) {
+    polyline.points.reserve(polyline.points.size() + collection.size());
+    polyline.points.insert(polyline.points.end(), collection.begin(),
                            collection.end());
   };
-  for (const auto& component : components_) {
+  // for (const auto& component : components_) {
+  for (size_t component_i = 0; component_i < components_.size();
+       component_i++) {
+    const auto& component = components_[component_i];
     switch (component.type) {
       case ComponentType::kLinear:
         collect_points(linears_[component.index].CreatePolyline());
@@ -222,9 +242,16 @@ Path::Polyline Path::CreatePolyline(
       case ComponentType::kCubic:
         collect_points(cubics_[component.index].CreatePolyline(approximation));
         break;
-      case ComponentType::kMove:
-        polyline.breaks.insert(polyline.points.size());
-        new_contour = true;
+      case ComponentType::kContour:
+        if (component_i == components_.size() - 1) {
+          // If the last component is a contour, that means it's an empty
+          // contour, so skip it.
+          continue;
+        }
+        const auto& contour = contours_[component.index];
+        collect_points({contour.destination});
+        polyline.contours.push_back({.start_index = polyline.points.size(),
+                                     .is_closed = contour.is_closed});
         break;
     }
   }

--- a/geometry/path_builder.cc
+++ b/geometry/path_builder.cc
@@ -174,10 +174,12 @@ PathBuilder& PathBuilder::AddRect(Rect rect) {
   auto br = rect.origin + Point{rect.size.width, rect.size.height};
   auto tr = rect.origin + Point{rect.size.width, 0.0};
 
-  prototype_.AddLinearComponent(tl, tr)
+  prototype_.AddContourComponent(tl)
+      .AddLinearComponent(tl, tr)
       .AddLinearComponent(tr, br)
       .AddLinearComponent(br, bl)
       .AddLinearComponent(bl, tl);
+  Close();
 
   return *this;
 }
@@ -202,6 +204,9 @@ PathBuilder& PathBuilder::AddRoundedRect(Rect rect, RoundingRadii radii) {
   const auto magic_bottom_right = radii.bottom_right * kArcApproximationMagic;
   const auto magic_bottom_left = radii.bottom_left * kArcApproximationMagic;
   const auto magic_top_left = radii.top_left * kArcApproximationMagic;
+
+  prototype_.AddContourComponent(
+      {rect.origin.x + radii.top_left.x, rect.origin.y}, true);
 
   //----------------------------------------------------------------------------
   // Top line.
@@ -279,6 +284,8 @@ PathBuilder& PathBuilder::AddRoundedRect(Rect rect, RoundingRadii radii) {
       {rect.origin.x + radii.top_left.x - magic_top_left.x, rect.origin.y},
       {rect.origin.x + radii.top_left.x, rect.origin.y});
 
+  Close();
+
   return *this;
 }
 
@@ -287,6 +294,8 @@ PathBuilder& PathBuilder::AddOval(const Rect& container) {
   const Point c = {container.origin.x + (container.size.width * 0.5f),
                    container.origin.y + (container.size.height * 0.5f)};
   const Point m = {kArcApproximationMagic * r.x, kArcApproximationMagic * r.y};
+
+  prototype_.AddContourComponent({c.x, c.y - r.y}, true);
 
   //----------------------------------------------------------------------------
   // Top right arc.
@@ -323,6 +332,8 @@ PathBuilder& PathBuilder::AddOval(const Rect& container) {
                                {c.x - m.x, c.y - r.y},  // cp2
                                {c.x, c.y - r.y}         // p2
   );
+
+  Close();
 
   return *this;
 }

--- a/geometry/path_builder.cc
+++ b/geometry/path_builder.cc
@@ -154,6 +154,7 @@ PathBuilder& PathBuilder::SmoothCubicCurveTo(Point controlPoint2,
 }
 
 PathBuilder& PathBuilder::AddQuadraticCurve(Point p1, Point cp, Point p2) {
+  MoveTo(p1);
   prototype_.AddQuadraticComponent(p1, cp, p2);
   return *this;
 }
@@ -162,6 +163,7 @@ PathBuilder& PathBuilder::AddCubicCurve(Point p1,
                                         Point cp1,
                                         Point cp2,
                                         Point p2) {
+  MoveTo(p1);
   prototype_.AddCubicComponent(p1, cp1, cp2, p2);
   return *this;
 }

--- a/geometry/path_builder.cc
+++ b/geometry/path_builder.cc
@@ -27,12 +27,14 @@ Path PathBuilder::TakePath(FillType fill) {
 PathBuilder& PathBuilder::MoveTo(Point point, bool relative) {
   current_ = relative ? current_ + point : point;
   subpath_start_ = current_;
-  prototype_.AddMoveComponent(current_);
+  prototype_.AddContourComponent(current_);
   return *this;
 }
 
 PathBuilder& PathBuilder::Close() {
   LineTo(subpath_start_);
+  prototype_.SetContourClosed(true);
+  prototype_.AddContourComponent(current_);
   return *this;
 }
 
@@ -344,8 +346,8 @@ PathBuilder& PathBuilder::AddPath(const Path& path) {
   auto cubic = [&](size_t index, const CubicPathComponent& c) {
     prototype_.AddCubicComponent(c.p1, c.cp1, c.cp2, c.p2);
   };
-  auto move = [&](size_t index, const MovePathComponent& m) {
-    prototype_.AddMoveComponent(m.destination);
+  auto move = [&](size_t index, const ContourComponent& m) {
+    prototype_.AddContourComponent(m.destination);
   };
   path.EnumerateComponents(linear, quadratic, cubic, move);
   return *this;

--- a/geometry/path_builder.cc
+++ b/geometry/path_builder.cc
@@ -174,8 +174,8 @@ PathBuilder& PathBuilder::AddRect(Rect rect) {
   auto br = rect.origin + Point{rect.size.width, rect.size.height};
   auto tr = rect.origin + Point{rect.size.width, 0.0};
 
-  prototype_.AddContourComponent(tl)
-      .AddLinearComponent(tl, tr)
+  MoveTo(tl);
+  prototype_.AddLinearComponent(tl, tr)
       .AddLinearComponent(tr, br)
       .AddLinearComponent(br, bl)
       .AddLinearComponent(bl, tl);
@@ -205,8 +205,7 @@ PathBuilder& PathBuilder::AddRoundedRect(Rect rect, RoundingRadii radii) {
   const auto magic_bottom_left = radii.bottom_left * kArcApproximationMagic;
   const auto magic_top_left = radii.top_left * kArcApproximationMagic;
 
-  prototype_.AddContourComponent(
-      {rect.origin.x + radii.top_left.x, rect.origin.y}, true);
+  MoveTo({rect.origin.x + radii.top_left.x, rect.origin.y});
 
   //----------------------------------------------------------------------------
   // Top line.
@@ -295,7 +294,7 @@ PathBuilder& PathBuilder::AddOval(const Rect& container) {
                    container.origin.y + (container.size.height * 0.5f)};
   const Point m = {kArcApproximationMagic * r.x, kArcApproximationMagic * r.y};
 
-  prototype_.AddContourComponent({c.x, c.y - r.y}, true);
+  MoveTo({c.x, c.y - r.y});
 
   //----------------------------------------------------------------------------
   // Top right arc.
@@ -339,6 +338,7 @@ PathBuilder& PathBuilder::AddOval(const Rect& container) {
 }
 
 PathBuilder& PathBuilder::AddLine(const Point& p1, const Point& p2) {
+  MoveTo(p1);
   prototype_.AddLinearComponent(p1, p2);
   return *this;
 }

--- a/geometry/path_component.cc
+++ b/geometry/path_component.cc
@@ -64,7 +64,7 @@ Point LinearPathComponent::Solve(Scalar time) const {
 }
 
 std::vector<Point> LinearPathComponent::CreatePolyline() const {
-  return {p1, p2};
+  return {p2};
 }
 
 std::vector<Point> LinearPathComponent::Extrema() const {

--- a/geometry/path_component.h
+++ b/geometry/path_component.h
@@ -107,15 +107,17 @@ struct CubicPathComponent {
   }
 };
 
-struct MovePathComponent {
+struct ContourComponent {
   Point destination;
+  bool is_closed;
 
-  MovePathComponent() {}
+  ContourComponent() {}
 
-  MovePathComponent(Point p) : destination(p) {}
+  ContourComponent(Point p, bool is_closed = false)
+      : destination(p), is_closed(is_closed) {}
 
-  bool operator==(const MovePathComponent& other) const {
-    return destination == other.destination;
+  bool operator==(const ContourComponent& other) const {
+    return destination == other.destination && is_closed == other.is_closed;
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/99177.
Also part of https://github.com/flutter/flutter/issues/99089.

  * `break`s are now `contour`s. They can never be empty, and the first contour is included in polylines (unless the path contains nothing).
  * A contour component is always inserted at 0, 0.
  * Closing a contour starts a new contour (bug fix).
  * Contours track `is_closed` state. This is unique information which can't be derived from point data.
  * Stroke content generates a final join for closed paths:
      

https://user-images.githubusercontent.com/919017/155943419-1388d943-0d62-4355-9f64-991bddf2672f.mov


  * Contours are guaranteed to never be empty:
    * Contiguous contour components are overridden while the path is being formed.
    * When generating polylines, the last contour is elided if it's empty.
  * Use a vector instead of an rb tree set to store contours because duplicate contours are elided prior to polyline generation.
  * While walking components for polyline creation, contour start points are appended. Other kinds of components always exclude their _first_ point (because it's guaranteed to always be identical to the _last_ point emitted by the previous component).
  * The stroke algorithm is way simpler/easier to understand now that it doesn't have to deal with any corner cases. Feeding the tessellator is simpler too.