### PR TITLE
Account for glyph extents in the atlas.

### DIFF
--- a/entity/contents.cc
+++ b/entity/contents.cc
@@ -635,11 +635,7 @@ bool TextContents::Render(const ContentContext& renderer,
   // Iterate through all the runs in the blob.
   for (const auto& run : frame_.GetRuns()) {
     auto font = run.GetFont();
-    auto glyph_size = font.GetGlyphSize();
-    if (!glyph_size.has_value()) {
-      VALIDATION_LOG << "Glyph has no size.";
-      return false;
-    }
+    auto glyph_size = ISize::Ceil(font.GetMetrics().GetBoundingBox().size);
     // Draw each glyph individually. This should probably be batched.
     for (const auto& glyph_position : run.GetGlyphPositions()) {
       FontGlyphPair font_glyph_pair{font, glyph_position.glyph};
@@ -651,9 +647,9 @@ bool TextContents::Render(const ContentContext& renderer,
 
       VS::GlyphInfo glyph_info;
       glyph_info.position = glyph_position.position.Translate(
-          {0.0, font.GetMetrics().ascent, 0.0});
-      glyph_info.glyph_size = {static_cast<Scalar>(glyph_size->width),
-                               static_cast<Scalar>(glyph_size->height)};
+          {font.GetMetrics().min_extent.x, font.GetMetrics().ascent, 0.0});
+      glyph_info.glyph_size = {static_cast<Scalar>(glyph_size.width),
+                               static_cast<Scalar>(glyph_size.height)};
       glyph_info.atlas_position = atlas_glyph_pos->origin;
       glyph_info.atlas_glyph_size = {atlas_glyph_pos->size.width,
                                      atlas_glyph_pos->size.height};

--- a/typographer/backends/skia/text_frame_skia.cc
+++ b/typographer/backends/skia/text_frame_skia.cc
@@ -22,6 +22,8 @@ static Font ToFont(const SkFont& font) {
   metrics.point_size = font.getSize();
   metrics.ascent = sk_metrics.fAscent;
   metrics.descent = sk_metrics.fDescent;
+  metrics.min_extent = {sk_metrics.fXMin, sk_metrics.fTop};
+  metrics.max_extent = {sk_metrics.fXMax, sk_metrics.fBottom};
 
   return Font{std::move(typeface), std::move(metrics)};
 }

--- a/typographer/font.cc
+++ b/typographer/font.cc
@@ -34,13 +34,6 @@ bool Font::IsEqual(const Font& other) const {
          is_valid_ == other.is_valid_ && metrics_ == other.metrics_;
 }
 
-std::optional<ISize> Font::GetGlyphSize() const {
-  if (!IsValid()) {
-    return std::nullopt;
-  }
-  return ISize::Ceil(typeface_->GetBoundingBox().size * metrics_.point_size);
-}
-
 const Font::Metrics& Font::GetMetrics() const {
   return metrics_;
 }

--- a/typographer/font.h
+++ b/typographer/font.h
@@ -44,10 +44,34 @@ class Font : public Comparable<Font> {
     /// yields larger numbers.
     ///
     Scalar descent = 0.0f;
+    //--------------------------------------------------------------------------
+    /// The minimum glyph extents relative to the origin. Typically negative in
+    /// an upper-left-origin coordinate system.
+    ///
+    Point min_extent;
+    //--------------------------------------------------------------------------
+    /// The maximum glyph extents relative to the origin. Typically positive in
+    /// an upper-left-origin coordinate system.
+    ///
+    Point max_extent;
+
+    //--------------------------------------------------------------------------
+    /// @brief      The union of the bounding boxes of all the glyphs.
+    ///
+    /// @return     The bounding box.
+    ///
+    constexpr Rect GetBoundingBox() const {
+      return Rect::MakeLTRB(min_extent.x,  //
+                            min_extent.y,  //
+                            max_extent.x,  //
+                            max_extent.y   //
+      );
+    }
 
     constexpr bool operator==(const Metrics& o) const {
       return point_size == o.point_size && ascent == o.ascent &&
-             descent == o.descent;
+             descent == o.descent && min_extent == o.min_extent &&
+             max_extent == o.max_extent;
     }
   };
 
@@ -63,14 +87,6 @@ class Font : public Comparable<Font> {
   /// @return     The typeface.
   ///
   const std::shared_ptr<Typeface>& GetTypeface() const;
-
-  //----------------------------------------------------------------------------
-  /// @brief      A conservatively large scaled bounding box of all glyphs in
-  ///             this font.
-  ///
-  /// @return     The scaled glyph size.
-  ///
-  std::optional<ISize> GetGlyphSize() const;
 
   const Metrics& GetMetrics() const;
 


### PR DESCRIPTION
Fixes the remaining issues w.r.t glyph atlases in the previous commit.
<img width="907" alt="Screen Shot 2022-02-28 at 12 32 07 PM" src="https://user-images.githubusercontent.com/44085/156055545-508eec9b-b123-4558-b52b-e78ee88ec1f5.png">

