### PR TITLE
Remove FML dependency on geometry, tessellator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Impeller itself may not depend on anything in `//flutter` except `//flutter/fml`
 and `flutter/display_list`. FML is a base library for C++ projects and Impeller
 implements the display list dispatcher interface to make it easy for Flutter to
 swap the renderer with Impeller. Impeller is meant to be used by the Flow
-(`//flutter/flow`) subsystem. Hence the name.
+(`//flutter/flow`) subsystem. Hence the name. The tessellator and geometry
+libraries are exceptions - they unconditionally may not depend on anything from
+`//flutter`.
 
 An overview of the major sub-frameworks, their responsibilities, and, relative
 states of completion:

--- a/aiks/BUILD.gn
+++ b/aiks/BUILD.gn
@@ -27,6 +27,14 @@ impeller_component("aiks") {
     "../entity",
     "../geometry",
   ]
+
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+  ]
 }
 
 impeller_component("aiks_unittests") {

--- a/archivist/BUILD.gn
+++ b/archivist/BUILD.gn
@@ -31,7 +31,14 @@ impeller_component("archivist") {
 
   public_deps = [ "../base" ]
 
-  deps = [ "//third_party/sqlite" ]
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+    "//third_party/sqlite",
+  ]
 }
 
 impeller_component("archivist_unittests") {

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -18,6 +18,14 @@ impeller_component("base") {
     "validation.cc",
     "validation.h",
   ]
+
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+  ]
 }
 
 impeller_component("base_unittests") {

--- a/base/config.h
+++ b/base/config.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "flutter/fml/build_config.h"
-
 #if defined(__GNUC__) || defined(__clang__)
 #define IMPELLER_COMPILER_CLANG 1
 #else  // defined(__GNUC__) || defined(__clang__)

--- a/entity/BUILD.gn
+++ b/entity/BUILD.gn
@@ -54,6 +54,15 @@ impeller_component("entity") {
     "../renderer",
     "../typographer",
   ]
+
+
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+  ]
 }
 
 impeller_component("entity_unittests") {

--- a/geometry/matrix_decomposition.h
+++ b/geometry/matrix_decomposition.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "flutter/fml/macros.h"
 #include "impeller/geometry/quaternion.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/shear.h"

--- a/geometry/path.cc
+++ b/geometry/path.cc
@@ -6,7 +6,6 @@
 
 #include <optional>
 
-#include "flutter/fml/logging.h"
 #include "impeller/geometry/path_component.h"
 
 namespace impeller {
@@ -19,8 +18,6 @@ Path::~Path() = default;
 
 std::tuple<size_t, size_t> Path::Polyline::GetContourPointBounds(
     size_t contour_index) const {
-  FML_DCHECK(contour_index < contours.size());
-
   const size_t start_index = contours[contour_index].start_index;
   const size_t end_index = (contour_index >= contours.size() - 1)
                                ? points.size()

--- a/geometry/path_builder.h
+++ b/geometry/path_builder.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "flutter/fml/macros.h"
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/geometry/scalar.h"
@@ -109,7 +108,8 @@ class PathBuilder {
 
   Point ReflectedCubicControlPoint1() const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PathBuilder);
+  PathBuilder(const PathBuilder&) = delete;
+  PathBuilder& operator=(const PathBuilder&&) = delete;
 };
 
 }  // namespace impeller

--- a/geometry/scalar.h
+++ b/geometry/scalar.h
@@ -7,7 +7,6 @@
 #include <cfloat>
 #include <valarray>
 
-#include "flutter/fml/logging.h"
 #include "impeller/geometry/constants.h"
 
 namespace impeller {
@@ -17,7 +16,6 @@ using Scalar = float;
 constexpr inline bool ScalarNearlyEqual(Scalar x,
                                         Scalar y,
                                         Scalar tolerance = 1e-3) {
-  FML_DCHECK(tolerance >= 0);
   return std::abs(x - y) <= tolerance;
 }
 

--- a/image/BUILD.gn
+++ b/image/BUILD.gn
@@ -17,11 +17,18 @@ impeller_component("image") {
     "decompressed_image.cc",
   ]
 
-  deps = [ "//third_party/skia" ]
-
   public_deps = [
     "../base",
     "../geometry",
+  ]
+
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+    "//third_party/skia",
   ]
 }
 

--- a/renderer/BUILD.gn
+++ b/renderer/BUILD.gn
@@ -110,6 +110,14 @@ impeller_component("renderer") {
     "../tessellator",
   ]
 
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+  ]
+
   frameworks = [ "Metal.framework" ]
 }
 

--- a/tessellator/BUILD.gn
+++ b/tessellator/BUILD.gn
@@ -27,7 +27,6 @@ shared_library("tessellator_shared") {
 
   deps = [
     "../geometry",
-    "//flutter/fml",
     "//third_party/libtess2",
   ]
 }

--- a/tessellator/tessellator.cc
+++ b/tessellator/tessellator.cc
@@ -4,8 +4,6 @@
 
 #include "impeller/tessellator/tessellator.h"
 
-#include "flutter/fml/logging.h"
-#include "flutter/fml/trace_event.h"
 #include "third_party/libtess2/Include/tesselator.h"
 
 namespace impeller {
@@ -38,7 +36,6 @@ static void DestroyTessellator(TESStesselator* tessellator) {
 
 bool Tessellator::Tessellate(const Path::Polyline& polyline,
                              VertexCallback callback) const {
-  TRACE_EVENT0("impeller", "Tessellator::Tessellate");
   if (!callback) {
     return false;
   }

--- a/tools/impeller.gni
+++ b/tools/impeller.gni
@@ -36,13 +36,6 @@ template("impeller_component") {
     cflags_objcc += flutter_cflags_objcc_arc + objc_warning_flags
 
     public_configs += [ "//flutter/impeller:impeller_public_config" ]
-
-    deps += [
-      "//flutter/fml",
-
-      # For tracing, seems to be pulled in by FML. Must be removed.
-      "//flutter/runtime:libdart",
-    ]
   }
 }
 

--- a/typographer/BUILD.gn
+++ b/typographer/BUILD.gn
@@ -36,6 +36,14 @@ impeller_component("typographer") {
     "../renderer",
     "//third_party/skia",
   ]
+
+  deps = [
+    "//flutter/fml",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+  ]
 }
 
 impeller_component("typographer_unittests") {


### PR DESCRIPTION
//flutter/fml depends on the Dart VM for _at least_ tracing and the implementation of `TimePoint::Now`. This is a very heavy dependency for the tessellation library, which really doesn't need it.

I've done the following:

- Dropped the FML dependency from `impeller_component`.
- Added the dependency to targets that still use it.
- Removed the dependency from `//flutter/impeller/geometry`, which only used it for some macros and DCHECKs
- Removed the dependency from `//flutter/impeller/tessellator`, which only used it for a single trace event.