### PR TITLE
Add a script that checks that all source files have a valid license block.

### DIFF
--- a/fixtures/sample.vert
+++ b/fixtures/sample.vert
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "types.h"
 
 uniform UniformBufferObject {

--- a/geometry/BUILD.gn
+++ b/geometry/BUILD.gn
@@ -8,6 +8,8 @@ impeller_component("geometry") {
   sources = [
     "color.cc",
     "color.h",
+    "constants.cc",
+    "constants.h",
     "matrix.cc",
     "matrix.h",
     "matrix_decomposition.cc",

--- a/geometry/constants.cc
+++ b/geometry/constants.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/geometry/constants.h"
+
+namespace impeller {
+
+//
+
+}  // namespace impeller

--- a/playground/imgui/BUILD.gn
+++ b/playground/imgui/BUILD.gn
@@ -1,3 +1,7 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 import("//flutter/impeller/tools/impeller.gni")
 
 impeller_shaders("imgui_shaders") {

--- a/playground/imgui/imgui_impl_impeller.cc
+++ b/playground/imgui/imgui_impl_impeller.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "imgui_impl_impeller.h"
 
 #include <algorithm>

--- a/playground/imgui/imgui_impl_impeller.h
+++ b/playground/imgui/imgui_impl_impeller.h
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 
 #include <memory>
@@ -5,8 +9,10 @@
 #include "third_party/imgui/imgui.h"
 
 namespace impeller {
+
 class Context;
 class RenderPass;
+
 }  // namespace impeller
 
 IMGUI_IMPL_API bool ImGui_ImplImpeller_Init(

--- a/playground/imgui/imgui_raster.frag
+++ b/playground/imgui/imgui_raster.frag
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 in vec2 frag_texture_coordinates;
 in vec4 frag_vertex_color;
 

--- a/playground/imgui/imgui_raster.vert
+++ b/playground/imgui/imgui_raster.vert
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 uniform UniformBuffer {
   mat4 mvp;
 }

--- a/tools/check_licenses.py
+++ b/tools/check_licenses.py
@@ -1,0 +1,74 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import os
+
+def ContainsLicenseBlock(source_file):
+  # This check is somewhat easier than in the engine because all sources need to
+  # have the same license.
+  py_license = '''# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.'''
+  c_license = py_license.replace("#", "//")
+
+  # Make sure we don't read the entire file into memory.
+  read_size = (max(len(py_license), len(c_license)))
+
+  for license in [c_license, py_license]:
+    with open(source_file) as source:
+      if source.read(read_size).startswith(license):
+        return True
+
+  return False
+
+def IsSourceFile(path):
+  known_extensions = [
+    ".cc",
+    ".cpp",
+    ".c",
+    ".h",
+    ".hpp",
+    ".py",
+    ".sh",
+    ".gn",
+    ".gni",
+    ".glsl",
+    ".sl.h",
+    ".vert",
+    ".frag",
+    ".tesc",
+    ".tese",
+    ".yaml",
+    ".dart",
+  ]
+  for extension in known_extensions:
+    if os.path.basename(path).endswith(extension):
+      return True
+  return False;
+
+# Checks that all source files have the same license preamble.
+def Main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--source-root",
+                    type=str, required=True,
+                    help="The source root.")
+  args = parser.parse_args()
+
+  assert(os.path.exists(args.source_root))
+
+  source_files = set()
+
+  for root, dirs, files in os.walk(os.path.abspath(args.source_root)):
+    for file in files:
+      file_path = os.path.join(root, file)
+      if IsSourceFile(file_path):
+        source_files.add(file_path)
+
+  for source_file in source_files:
+    if not ContainsLicenseBlock(source_file):
+      raise Exception("Could not find valid license block in source ", source_file)
+
+if __name__ == '__main__':
+  Main()

--- a/tools/check_licenses.py
+++ b/tools/check_licenses.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 
+
 def ContainsLicenseBlock(source_file):
   # This check is somewhat easier than in the engine because all sources need to
   # have the same license.
@@ -22,6 +23,7 @@ def ContainsLicenseBlock(source_file):
         return True
 
   return False
+
 
 def IsSourceFile(path):
   known_extensions = [
@@ -47,6 +49,7 @@ def IsSourceFile(path):
     if os.path.basename(path).endswith(extension):
       return True
   return False;
+
 
 # Checks that all source files have the same license preamble.
 def Main():


### PR DESCRIPTION
Also fixes the files with missing licenses. This check is somewhat easy with
Impeller than in the engine because all source files must have the same license
block.

Resolves an action item in the umbrella issue https://github.com/flutter/flutter/issues/97686

The script may eventually be run as part of a CI step.