### PR TITLE
Chainable texture filters

### DIFF
--- a/entity/BUILD.gn
+++ b/entity/BUILD.gn
@@ -29,6 +29,8 @@ impeller_component("entity") {
     "contents/content_context.h",
     "contents/contents.cc",
     "contents/contents.h",
+    "contents/filter_contents.cc",
+    "contents/filter_contents.h",
     "contents/linear_gradient_contents.cc",
     "contents/linear_gradient_contents.h",
     "contents/solid_color_contents.cc",
@@ -54,7 +56,6 @@ impeller_component("entity") {
     "../renderer",
     "../typographer",
   ]
-
 
   deps = [
     "//flutter/fml",

--- a/entity/contents/content_context.h
+++ b/entity/contents/content_context.h
@@ -159,6 +159,12 @@ class ContentContext {
         color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
         color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
         break;
+      case Entity::BlendMode::kPlus:
+        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.dst_color_blend_factor = BlendFactor::kOne;
+        color0.src_alpha_blend_factor = BlendFactor::kSourceAlpha;
+        color0.src_color_blend_factor = BlendFactor::kOne;
+        break;
     }
     desc.SetColorAttachmentDescriptor(0u, std::move(color0));
   }

--- a/entity/contents/filter_contents.cc
+++ b/entity/contents/filter_contents.cc
@@ -1,0 +1,97 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filter_contents.h"
+
+#include <memory>
+#include <optional>
+#include <variant>
+
+#include "base/validation.h"
+#include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/solid_color_contents.h"
+#include "impeller/entity/entity.h"
+#include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/render_pass.h"
+
+namespace impeller {
+
+FilterContents::FilterContents() = default;
+
+FilterContents::~FilterContents() = default;
+
+void FilterContents::SetTextures(InputTextures input_textures) {
+  input_textures_ = std::move(input_textures);
+}
+
+static std::optional<std::shared_ptr<Texture>> RenderDependency(
+    const ContentContext& renderer,
+    const Entity& entity,
+    RenderPass& pass,
+    std::shared_ptr<FilterContents>& input) {
+  auto context = renderer.GetContext();
+
+  // TODO(bdero): Use texture params for size and add optional xform input for
+  //              transform?
+  auto subpass_target =
+      RenderTarget::CreateOffscreen(*context, pass.GetRenderTargetSize());
+  auto subpass_texture = subpass_target.GetRenderTargetTexture();
+  if (!subpass_texture) {
+    return std::nullopt;
+  }
+
+  auto sub_command_buffer = context->CreateRenderCommandBuffer();
+  sub_command_buffer->SetLabel("Offscreen Filter Command Buffer");
+  if (!sub_command_buffer) {
+    return std::nullopt;
+  }
+
+  auto sub_renderpass = sub_command_buffer->CreateRenderPass(subpass_target);
+  if (!sub_renderpass) {
+    return std::nullopt;
+  }
+  sub_renderpass->SetLabel("OffscreenFilterPass");
+
+  if (!input->Render(renderer, entity, *sub_renderpass)) {
+    return std::nullopt;
+  }
+
+  if (!sub_renderpass->EncodeCommands(*context->GetTransientsAllocator())) {
+    return std::nullopt;
+  }
+
+  if (!sub_command_buffer->SubmitCommands()) {
+    return std::nullopt;
+  }
+
+  return subpass_texture;
+}
+
+bool FilterContents::Render(const ContentContext& renderer,
+                            const Entity& entity,
+                            RenderPass& pass) const {
+  std::vector<std::shared_ptr<Texture>> texture_params;
+  texture_params.reserve(input_textures_.size());
+
+  // Render input dependencies.
+  for (auto input : input_textures_) {
+    if (std::holds_alternative<std::shared_ptr<FilterContents>>(input)) {
+      auto& filter = std::get<std::shared_ptr<FilterContents>>(input);
+      auto texture = RenderDependency(renderer, entity, pass, filter);
+      if (!texture.has_value()) {
+        return false;
+      }
+      texture_params.push_back(std::move(texture.value()));
+    } else {
+      auto& texture = std::get<std::shared_ptr<Texture>>(input);
+      texture_params.push_back(std::move(texture));
+    }
+  }
+
+  Command cmd;
+  pass.AddCommand(std::move(cmd));
+  return true;
+}
+
+}  // namespace impeller

--- a/entity/contents/filter_contents.cc
+++ b/entity/contents/filter_contents.cc
@@ -157,8 +157,6 @@ bool BlendFilterContents::RenderFilter(
     const std::vector<std::shared_ptr<Texture>>& input_textures,
     const ContentContext& renderer,
     RenderPass& pass) const {
-  auto size = pass.GetRenderTargetSize();
-
   using VS = TexturePipeline::VertexShader;
   using FS = TexturePipeline::FragmentShader;
 
@@ -166,17 +164,17 @@ bool BlendFilterContents::RenderFilter(
 
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
-      {Point(0, 0)},
-      {Point(size.width, 0)},
-      {Point(size.width, size.height)},
-      {Point(0, 0)},
-      {Point(size.width, size.height)},
-      {Point(0, size.height)},
+      {Point(0, 0), Point(0, 0)},
+      {Point(1, 0), Point(1, 0)},
+      {Point(1, 1), Point(1, 1)},
+      {Point(0, 0), Point(0, 0)},
+      {Point(1, 1), Point(1, 1)},
+      {Point(0, 1), Point(0, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+  frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
   frame_info.alpha = 1;
   auto uniform_view = host_buffer.EmplaceUniform(frame_info);
 

--- a/entity/contents/filter_contents.h
+++ b/entity/contents/filter_contents.h
@@ -15,14 +15,26 @@ namespace impeller {
 
 class FilterContents : public Contents {
  public:
-  using InputTextures = std::vector<
-      std::variant<std::shared_ptr<Texture>, std::shared_ptr<FilterContents>>>;
+  using InputVariant =
+      std::variant<std::shared_ptr<Texture>, std::shared_ptr<FilterContents>>;
+  using InputTextures = std::vector<InputVariant>;
 
   FilterContents();
 
   ~FilterContents();
 
-  void SetTextures(InputTextures input_textures);
+  /// @brief The input texture sources for this filter. All texture sources are
+  ///        expected to have or produce premultiplied alpha colors.
+  ///        Any input can either be a `Texture` or another `FilterContents`.
+  ///
+  ///        The number of required or optional textures depends on the
+  ///        particular filter's implementation.
+  void SetInputTextures(InputTextures& input_textures);
+
+  /// @brief Set the render target destination rect for rendering this filter.
+  ///        For chained filters, this is only used for the last filter in the
+  ///        chain.
+  void SetDestination(const Rect& destination);
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -30,12 +42,25 @@ class FilterContents : public Contents {
               RenderPass& pass) const override;
 
  private:
-  virtual bool RenderFilter(const ContentContext& renderer,
-                            const Entity& entity,
-                            RenderPass& pass) const = 0;
+  /// @brief Takes a set of zero or more input textures and writes to an output
+  ///        texture.
+  virtual bool RenderFilter(
+      const std::vector<std::shared_ptr<Texture>>& input_textures,
+      const ContentContext& renderer,
+      RenderPass& subpass) const = 0;
+
+  /// @brief Determines the size of the output texture.
+  virtual ISize GetOutputSize() const;
+
+  /// @brief Renders dependency filters, creates a subpass, and calls the
+  ///        `RenderFilter` defined by the subclasses.
+  std::optional<std::shared_ptr<Texture>> RenderFilterToTexture(
+      const ContentContext& renderer,
+      const Entity& entity,
+      RenderPass& pass) const;
 
   InputTextures input_textures_;
-  std::vector<std::shared_ptr<Texture>> inpur_textures_;
+  Rect destination_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FilterContents);
 };

--- a/entity/contents/filter_contents.h
+++ b/entity/contents/filter_contents.h
@@ -30,7 +30,7 @@ class FilterContents : public Contents {
 
   FilterContents();
 
-  ~FilterContents();
+  ~FilterContents() override;
 
   /// @brief The input texture sources for this filter. All texture sources are
   ///        expected to have or produce premultiplied alpha colors.
@@ -38,7 +38,7 @@ class FilterContents : public Contents {
   ///
   ///        The number of required or optional textures depends on the
   ///        particular filter's implementation.
-  void SetInputTextures(InputTextures& input_textures);
+  void SetInputTextures(InputTextures input_textures);
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -77,7 +77,7 @@ class BlendFilterContents : public FilterContents {
  public:
   BlendFilterContents();
 
-  ~BlendFilterContents();
+  ~BlendFilterContents() override;
 
   void SetBlendMode(Entity::BlendMode blend_mode);
 

--- a/entity/contents/filter_contents.h
+++ b/entity/contents/filter_contents.h
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "impeller/entity/contents/contents.h"
+#include "impeller/renderer/formats.h"
+
+namespace impeller {
+
+class FilterContents : public Contents {
+ public:
+  using InputTextures = std::vector<
+      std::variant<std::shared_ptr<Texture>, std::shared_ptr<FilterContents>>>;
+
+  FilterContents();
+
+  ~FilterContents();
+
+  void SetTextures(InputTextures input_textures);
+
+  // |Contents|
+  bool Render(const ContentContext& renderer,
+              const Entity& entity,
+              RenderPass& pass) const override;
+
+ private:
+  virtual bool RenderFilter(const ContentContext& renderer,
+                            const Entity& entity,
+                            RenderPass& pass) const = 0;
+
+  InputTextures input_textures_;
+  std::vector<std::shared_ptr<Texture>> inpur_textures_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FilterContents);
+};
+
+}  // namespace impeller

--- a/entity/contents/filter_contents.h
+++ b/entity/contents/filter_contents.h
@@ -40,11 +40,6 @@ class FilterContents : public Contents {
   ///        particular filter's implementation.
   void SetInputTextures(InputTextures& input_textures);
 
-  /// @brief Set the render target destination rect for rendering this filter.
-  ///        For chained filters, this is only used for the last filter in the
-  ///        chain.
-  void SetDestination(const Rect& destination);
-
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -65,7 +65,8 @@ void Entity::IncrementStencilDepth(uint32_t increment) {
   stencil_depth_ += increment;
 }
 
-bool Entity::Render(ContentContext& renderer, RenderPass& parent_pass) const {
+bool Entity::Render(const ContentContext& renderer,
+                    RenderPass& parent_pass) const {
   if (!contents_) {
     return true;
   }

--- a/entity/entity.h
+++ b/entity/entity.h
@@ -27,6 +27,7 @@ class Entity {
     kDestination,
     kSourceOver,
     kDestinationOver,
+    kPlus,
   };
 
   Entity();

--- a/entity/entity.h
+++ b/entity/entity.h
@@ -57,7 +57,7 @@ class Entity {
 
   uint32_t GetStencilDepth() const;
 
-  bool Render(ContentContext& renderer, RenderPass& parent_pass) const;
+  bool Render(const ContentContext& renderer, RenderPass& parent_pass) const;
 
  private:
   Matrix transformation_;

--- a/entity/entity_pass.cc
+++ b/entity/entity_pass.cc
@@ -75,7 +75,7 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
     return entities_coverage;
   }
 
-  // If the delete tells us the coverage is smaller than it needs to be, then
+  // If the delegate tells us the coverage is smaller than it needs to be, then
   // great. OTOH, if the delegate is being wasteful, limit coverage to what is
   // actually needed.
   return entities_coverage->Intersection(delegate_coverage.value());

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -634,7 +634,6 @@ TEST_F(EntityTest, Filters) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     auto blend =
         FilterContents::MakeBlend(Entity::BlendMode::kPlus, {bridge, boston});
-    blend->SetDestination(Rect(100, 100, 300, 300));
 
     Entity entity;
     entity.SetPath({});

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "entity/contents/filter_contents.h"
 #include "flutter/testing/testing.h"
 #include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
@@ -521,6 +522,9 @@ TEST_F(EntityTest, BlendingModeOptions) {
       case Entity::BlendMode::kDestinationOver:
         blend_mode_names.push_back("DestinationOver");
         blend_mode_values.push_back(Entity::BlendMode::kDestinationOver);
+      case Entity::BlendMode::kPlus:
+        blend_mode_names.push_back("Plus");
+        blend_mode_values.push_back(Entity::BlendMode::kPlus);
     };
   }
 
@@ -616,9 +620,28 @@ TEST_F(EntityTest, BezierCircleScaled) {
                   .Close()
                   .TakePath();
   entity.SetPath(path);
-  entity.SetTransformation(Matrix::MakeScale({20.0, 20.0, 1.0}).Translate({-80, -15, 0}));
+  entity.SetTransformation(
+      Matrix::MakeScale({20.0, 20.0, 1.0}).Translate({-80, -15, 0}));
   entity.SetContents(SolidColorContents::Make(Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
+}
+
+TEST_F(EntityTest, Filters) {
+  auto bridge = CreateTextureForFixture("bay_bridge.jpg");
+  auto boston = CreateTextureForFixture("boston.jpg");
+  ASSERT_TRUE(bridge && boston);
+
+  auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
+    auto blend =
+        FilterContents::MakeBlend(Entity::BlendMode::kPlus, {bridge, boston});
+    blend->SetDestination(Rect(100, 100, 300, 300));
+
+    Entity entity;
+    entity.SetPath({});
+    entity.SetContents(blend);
+    return entity.Render(context, pass);
+  };
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "entity/contents/filter_contents.h"
 #include "flutter/testing/testing.h"
+#include "impeller/entity/contents/filter_contents.h"
 #include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
 #include "impeller/entity/entity.h"
@@ -636,7 +636,7 @@ TEST_F(EntityTest, Filters) {
         FilterContents::MakeBlend(Entity::BlendMode::kPlus, {bridge, boston});
 
     Entity entity;
-    entity.SetPath({});
+    entity.SetPath(PathBuilder{}.AddRect({100, 100, 300, 300}).TakePath());
     entity.SetContents(blend);
     return entity.Render(context, pass);
   };

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -629,15 +629,21 @@ TEST_F(EntityTest, BezierCircleScaled) {
 TEST_F(EntityTest, Filters) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
-  ASSERT_TRUE(bridge && boston);
+  auto kalimba = CreateTextureForFixture("kalimba.jpg");
+  ASSERT_TRUE(bridge && boston && kalimba);
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
-    auto blend =
-        FilterContents::MakeBlend(Entity::BlendMode::kPlus, {bridge, boston});
+    // Draws kalimba and overwrites it with boston.
+    auto blend0 = FilterContents::MakeBlend(
+        Entity::BlendMode::kSourceOver, {kalimba, boston});
+
+    // Adds bridge*3 to boston.
+    auto blend1 = FilterContents::MakeBlend(
+        Entity::BlendMode::kPlus, {bridge, bridge, blend0, bridge});
 
     Entity entity;
     entity.SetPath(PathBuilder{}.AddRect({100, 100, 300, 300}).TakePath());
-    entity.SetContents(blend);
+    entity.SetContents(blend1);
     return entity.Render(context, pass);
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/99521.

* Add `FilterContents` class that take zero or more texture inputs and generates a result texture.
  * Any input may either be an `impeller::Texture` or another `FilterContents` which will get resolved at render time.
  * When the `FilterContents` is rendered with an entity, it draws the output texture to the parent pass via `TextureContents` and respects the entity's transform/stencil/path.
  * By default, the size of the first input texture is used as the size of the result texture, but filters may override this behavior depending on the use case. For example, a convolution filter (such as a Gaussian blur) may optionally increase the size of the result texture by a factor of the blur radius.
* Add `BlendFilterContents` filter for simple additive blending/merging textures together.
  * Currently, input textures that don't match the size of the first texture stretch.
* Add `Entity::BlendMode::kPlus` blend mode. 

Right now the test just blends 3 fixtures together. Will make fancier tests once we have less trivial filters to work with.

![image](https://user-images.githubusercontent.com/919017/157564298-e3a8e211-23b6-4154-aede-1353137543fb.png)

Usage:
```cpp
    auto bridge = CreateTextureForFixture("bay_bridge.jpg");
    auto boston = CreateTextureForFixture("boston.jpg");
    auto kalimba = CreateTextureForFixture("kalimba.jpg");

    // Draws kalimba and alpha blends boston over it.
    auto blend0 = FilterContents::MakeBlend(
        Entity::BlendMode::kSourceOver, {kalimba, boston});

    // Adds bridge*3 and the result of the first blend together.
    auto blend1 = FilterContents::MakeBlend(
        Entity::BlendMode::kPlus, {bridge, bridge, blend0, bridge});

    Entity entity;
    entity.SetPath(PathBuilder{}.AddRect({100, 100, 300, 300}).TakePath());
    entity.SetContents(blend1);
    entity.Render(context, pass);
```