### PR TITLE
Correct default blend mode, fix solid stroke shader to respect premultiplied source colors

### DIFF
--- a/entity/contents/content_context.h
+++ b/entity/contents/content_context.h
@@ -40,7 +40,7 @@ using ClipPipeline = PipelineT<SolidFillVertexShader, SolidFillFragmentShader>;
 
 struct ContentContextOptions {
   SampleCount sample_count = SampleCount::kCount1;
-  Entity::BlendMode blend_mode = Entity::BlendMode::kSource;
+  Entity::BlendMode blend_mode = Entity::BlendMode::kSourceOver;
 
   struct Hash {
     constexpr std::size_t operator()(const ContentContextOptions& o) const {

--- a/entity/shaders/solid_stroke.frag
+++ b/entity/shaders/solid_stroke.frag
@@ -8,6 +8,5 @@ in float v_pen_down;
 out vec4 frag_color;
 
 void main() {
-  frag_color = stroke_color;
-  frag_color.a *= floor(v_pen_down);
+  frag_color = stroke_color * floor(v_pen_down);
 }


### PR DESCRIPTION
While writing https://github.com/flutter/impeller/pull/68 I noticed visible geometry appearing between disconnected contours in the entity tests. It turns out I accidentally set the default blend mode to `kSource` rather than `kSourceOver` when adding blend modes, and I forgot to update the stroke shader to respect premultiplied source colors.

@chinmaygarde Was this the path-related regression you mentioned earlier?

Before:
![Screen Shot 2022-03-09 at 9 34 58 PM](https://user-images.githubusercontent.com/919017/157598476-67cc3ace-b901-4448-bdb6-4f7fe1a25f2b.png)

After:
![Screen Shot 2022-03-09 at 9 49 27 PM](https://user-images.githubusercontent.com/919017/157598459-7c876f9e-50f5-40f3-8ace-947e800d26de.png)
