### PR TITLE
Only depend on FML for tracing when building executables.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -37,5 +37,9 @@ executable("impeller_unittests") {
     "playground",
     "renderer:renderer_unittests",
     "typographer:typographer_unittests",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
   ]
 }

--- a/aiks/BUILD.gn
+++ b/aiks/BUILD.gn
@@ -28,13 +28,7 @@ impeller_component("aiks") {
     "../geometry",
   ]
 
-  deps = [
-    "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
-  ]
+  deps = [ "//flutter/fml" ]
 }
 
 impeller_component("aiks_unittests") {

--- a/archivist/BUILD.gn
+++ b/archivist/BUILD.gn
@@ -33,10 +33,6 @@ impeller_component("archivist") {
 
   deps = [
     "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
     "//third_party/sqlite",
   ]
 }

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -21,13 +21,7 @@ impeller_component("base") {
     "validation.h",
   ]
 
-  deps = [
-    "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
-  ]
+  deps = [ "//flutter/fml" ]
 }
 
 impeller_component("base_unittests") {

--- a/compiler/BUILD.gn
+++ b/compiler/BUILD.gn
@@ -23,7 +23,6 @@ impeller_component("compiler_lib") {
     "../base",
     "../geometry",
     "//flutter/fml",
-    "//flutter/runtime:libdart",
     "//third_party/inja",
     "//third_party/shaderc_flutter",
     "//third_party/spirv_cross_flutter",
@@ -35,7 +34,13 @@ impeller_component("impellerc") {
 
   sources = [ "impellerc_main.cc" ]
 
-  deps = [ ":compiler_lib" ]
+  deps = [
+    ":compiler_lib",
+
+    # FML depends on the Dart VM for tracing and getting the current
+    # timepoint.
+    "//flutter/runtime:libdart",
+  ]
 }
 
 group("compiler") {

--- a/entity/BUILD.gn
+++ b/entity/BUILD.gn
@@ -57,13 +57,7 @@ impeller_component("entity") {
     "../typographer",
   ]
 
-  deps = [
-    "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
-  ]
+  deps = [ "//flutter/fml" ]
 }
 
 impeller_component("entity_unittests") {

--- a/image/BUILD.gn
+++ b/image/BUILD.gn
@@ -24,10 +24,6 @@ impeller_component("image") {
 
   deps = [
     "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
     "//third_party/skia",
   ]
 }

--- a/renderer/BUILD.gn
+++ b/renderer/BUILD.gn
@@ -108,13 +108,7 @@ impeller_component("renderer") {
     "../tessellator",
   ]
 
-  deps = [
-    "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
-  ]
+  deps = [ "//flutter/fml" ]
 
   frameworks = [ "Metal.framework" ]
 }

--- a/typographer/BUILD.gn
+++ b/typographer/BUILD.gn
@@ -37,13 +37,7 @@ impeller_component("typographer") {
     "//third_party/skia",
   ]
 
-  deps = [
-    "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
-  ]
+  deps = [ "//flutter/fml" ]
 }
 
 impeller_component("typographer_unittests") {


### PR DESCRIPTION
Otherwise, depending on Impeller will cause an explicit dependency on
whatever VM variant :libdart picks. And, some other unit-test in the
engine explicitly link in the JIT variant which leads to duplicate
symbol errors in profile and release modes.

Towards fixing profile and release builds in https://github.com/flutter/engine/pull/31959