### PR TITLE
Add remaining simple blend modes

### DIFF
--- a/entity/contents/content_context.h
+++ b/entity/contents/content_context.h
@@ -159,11 +159,60 @@ class ContentContext {
         color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
         color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
         break;
-      case Entity::BlendMode::kPlus:
+      case Entity::BlendMode::kSourceIn:
+        color0.dst_alpha_blend_factor = BlendFactor::kZero;
+        color0.dst_color_blend_factor = BlendFactor::kZero;
+        color0.src_alpha_blend_factor = BlendFactor::kDestinationAlpha;
+        color0.src_color_blend_factor = BlendFactor::kDestinationAlpha;
+        break;
+      case Entity::BlendMode::kDestinationIn:
+        color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
+        color0.dst_color_blend_factor = BlendFactor::kSourceAlpha;
+        color0.src_alpha_blend_factor = BlendFactor::kZero;
+        color0.src_color_blend_factor = BlendFactor::kZero;
+        break;
+      case Entity::BlendMode::kSourceOut:
+        color0.dst_alpha_blend_factor = BlendFactor::kZero;
+        color0.dst_color_blend_factor = BlendFactor::kZero;
+        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+        break;
+      case Entity::BlendMode::kDestinationOut:
         color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.src_alpha_blend_factor = BlendFactor::kZero;
+        color0.src_color_blend_factor = BlendFactor::kZero;
+        break;
+      case Entity::BlendMode::kSourceATop:
+        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.src_alpha_blend_factor = BlendFactor::kDestinationAlpha;
+        color0.src_color_blend_factor = BlendFactor::kDestinationAlpha;
+        break;
+      case Entity::BlendMode::kDestinationATop:
+        color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
+        color0.dst_color_blend_factor = BlendFactor::kSourceAlpha;
+        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+        break;
+      case Entity::BlendMode::kXor:
+        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+        break;
+      case Entity::BlendMode::kPlus:
+        color0.dst_alpha_blend_factor = BlendFactor::kOne;
         color0.dst_color_blend_factor = BlendFactor::kOne;
-        color0.src_alpha_blend_factor = BlendFactor::kSourceAlpha;
+        color0.src_alpha_blend_factor = BlendFactor::kOne;
         color0.src_color_blend_factor = BlendFactor::kOne;
+        break;
+      case Entity::BlendMode::kModulate:
+        // kSourceColor and kDestinationColor override the alpha blend factor.
+        color0.dst_alpha_blend_factor = BlendFactor::kZero;
+        color0.dst_color_blend_factor = BlendFactor::kSourceColor;
+        color0.src_alpha_blend_factor = BlendFactor::kZero;
+        color0.src_color_blend_factor = BlendFactor::kZero;
         break;
     }
     desc.SetColorAttachmentDescriptor(0u, std::move(color0));

--- a/entity/entity.h
+++ b/entity/entity.h
@@ -27,7 +27,15 @@ class Entity {
     kDestination,
     kSourceOver,
     kDestinationOver,
+    kSourceIn,
+    kDestinationIn,
+    kSourceOut,
+    kDestinationOut,
+    kSourceATop,
+    kDestinationATop,
+    kXor,
     kPlus,
+    kModulate,
   };
 
   Entity();

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -522,9 +522,33 @@ TEST_F(EntityTest, BlendingModeOptions) {
       case Entity::BlendMode::kDestinationOver:
         blend_mode_names.push_back("DestinationOver");
         blend_mode_values.push_back(Entity::BlendMode::kDestinationOver);
+      case Entity::BlendMode::kSourceIn:
+        blend_mode_names.push_back("SourceIn");
+        blend_mode_values.push_back(Entity::BlendMode::kSourceIn);
+      case Entity::BlendMode::kDestinationIn:
+        blend_mode_names.push_back("DestinationIn");
+        blend_mode_values.push_back(Entity::BlendMode::kDestinationIn);
+      case Entity::BlendMode::kSourceOut:
+        blend_mode_names.push_back("SourceOut");
+        blend_mode_values.push_back(Entity::BlendMode::kSourceOut);
+      case Entity::BlendMode::kDestinationOut:
+        blend_mode_names.push_back("DestinationOut");
+        blend_mode_values.push_back(Entity::BlendMode::kDestinationOut);
+      case Entity::BlendMode::kSourceATop:
+        blend_mode_names.push_back("SourceATop");
+        blend_mode_values.push_back(Entity::BlendMode::kSourceATop);
+      case Entity::BlendMode::kDestinationATop:
+        blend_mode_names.push_back("DestinationATop");
+        blend_mode_values.push_back(Entity::BlendMode::kDestinationATop);
+      case Entity::BlendMode::kXor:
+        blend_mode_names.push_back("Xor");
+        blend_mode_values.push_back(Entity::BlendMode::kXor);
       case Entity::BlendMode::kPlus:
         blend_mode_names.push_back("Plus");
         blend_mode_values.push_back(Entity::BlendMode::kPlus);
+      case Entity::BlendMode::kModulate:
+        blend_mode_names.push_back("Modulate");
+        blend_mode_values.push_back(Entity::BlendMode::kModulate);
     };
   }
 


### PR DESCRIPTION
This covers all of the remaining blends that are possible to implement using widely supported pipeline blend parameters. 

https://user-images.githubusercontent.com/919017/158262973-28a374c8-7c2a-4044-9de3-be2d0ad0e68c.mov

The other 15 blend modes must be implemented with fragment shaders or blend equation extensions (such as `GL_KHR_blend_equation_advanced` and `VK_EXT_blend_operation_advanced`) (see also: https://github.com/flutter/flutter/issues/100086))