### PR TITLE
Fix issues with constexpr correctness.

### DIFF
--- a/geometry/scalar.h
+++ b/geometry/scalar.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cfloat>
+#include <type_traits>
 #include <valarray>
 
 #include "impeller/geometry/constants.h"
@@ -13,10 +14,15 @@ namespace impeller {
 
 using Scalar = float;
 
+template <class T, class = std::enable_if_t<std::is_arithmetic_v<T>>>
+constexpr T Absolute(const T& val) {
+  return val >= T{} ? val : -val;
+}
+
 constexpr inline bool ScalarNearlyEqual(Scalar x,
                                         Scalar y,
                                         Scalar tolerance = 1e-3) {
-  return std::abs(x - y) <= tolerance;
+  return Absolute(x - y) <= tolerance;
 }
 
 struct Degrees;

--- a/geometry/vector.h
+++ b/geometry/vector.h
@@ -41,7 +41,7 @@ struct Vector3 {
    *
    *  @return the calculated length.
    */
-  constexpr Scalar Length() const { return sqrt(x * x + y * y + z * z); }
+  Scalar Length() const { return sqrt(x * x + y * y + z * z); }
 
   constexpr Vector3 Normalize() const {
     const auto len = Length();
@@ -125,7 +125,7 @@ struct Vector4 {
 
   constexpr Vector4(const Point& p) : x(p.x), y(p.y) {}
 
-  constexpr Vector4 Normalize() const {
+  Vector4 Normalize() const {
     const Scalar inverse = 1.0 / sqrt(x * x + y * y + z * z + w * w);
     return Vector4(x * inverse, y * inverse, z * inverse, w * inverse);
   }

--- a/renderer/backend/metal/formats_mtl.h
+++ b/renderer/backend/metal/formats_mtl.h
@@ -294,7 +294,7 @@ constexpr MTLSamplerAddressMode ToMTLSamplerAddressMode(
   return MTLSamplerAddressModeClampToEdge;
 }
 
-constexpr MTLClearColor ToMTLClearColor(const Color& color) {
+inline MTLClearColor ToMTLClearColor(const Color& color) {
   return MTLClearColorMake(color.red, color.green, color.blue, color.alpha);
 }
 


### PR DESCRIPTION
Some like std::abs are not available till C++23. The others were
real warnings.

For https://github.com/flutter/engine/pull/31959