### PR TITLE
Add cast necessary on 32-bit arm builds.

### DIFF
--- a/renderer/backend/metal/render_pass_mtl.mm
+++ b/renderer/backend/metal/render_pass_mtl.mm
@@ -243,7 +243,7 @@ struct PassBindingsCache {
       }
       return true;
     }
-    buffers_map[index] = {buffer, offset};
+    buffers_map[index] = {buffer, static_cast<size_t>(offset)};
     switch (stage) {
       case ShaderStage::kVertex:
         [encoder_ setVertexBuffer:buffer offset:offset atIndex:index];


### PR DESCRIPTION
Offset is a uint64_t that needs a cast.

For https://github.com/flutter/engine/pull/31959