### PR TITLE
Add blend mode setting to Entity, Aiks paint, and the dispatcher

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -398,5 +398,24 @@ TEST_F(AiksTest, CanDrawPaint) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_F(AiksTest, PaintBlendModeIsRespected) {
+  Paint paint;
+  Canvas canvas;
+  // Default is kSourceOver.
+  paint.color = Color(1, 0, 0, 0.5);
+  canvas.DrawCircle(Point(150, 200), 100, paint);
+  paint.color = Color(0, 1, 0, 0.5);
+  canvas.DrawCircle(Point(250, 200), 100, paint);
+
+  paint.blend_mode = Entity::BlendMode::kPlus;
+  paint.color = Color::Red();
+  canvas.DrawCircle(Point(450, 250), 100, paint);
+  paint.color = Color::Green();
+  canvas.DrawCircle(Point(550, 250), 100, paint);
+  paint.color = Color::Blue();
+  canvas.DrawCircle(Point(500, 150), 100, paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -109,6 +109,7 @@ void Canvas::DrawPath(Path path, Paint paint) {
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetPath(std::move(path));
   entity.SetStencilDepth(GetStencilDepth());
+  entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(paint.CreateContentsForEntity());
 
   GetCurrentPass().AddEntity(std::move(entity));
@@ -118,6 +119,7 @@ void Canvas::DrawPaint(Paint paint) {
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());
+  entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(
       std::make_shared<ClearContents>(paint.CreateContentsForEntity()));
 
@@ -227,6 +229,7 @@ void Canvas::DrawImageRect(std::shared_ptr<Image> image,
 
   Entity entity;
   entity.SetPath(PathBuilder{}.AddRect(dest).TakePath());
+  entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(contents);
   entity.SetTransformation(GetCurrentTransformation());
 
@@ -284,6 +287,7 @@ void Canvas::DrawTextFrame(TextFrame text_frame,
                            Matrix::MakeTranslation(position));
   entity.SetPath({});
   entity.SetStencilDepth(GetStencilDepth());
+  entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(std::move(text_contents));
 
   GetCurrentPass().AddEntity(std::move(entity));

--- a/aiks/paint.h
+++ b/aiks/paint.h
@@ -8,6 +8,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/contents.h"
+#include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
 
 namespace impeller {
@@ -21,6 +22,7 @@ struct Paint {
   Color color = Color::Black();
   Scalar stroke_width = 0.0;
   Style style = Style::kFill;
+  Entity::BlendMode blend_mode = Entity::BlendMode::kSourceOver;
   std::shared_ptr<Contents> contents;
 
   std::shared_ptr<Contents> CreateContentsForEntity() const;

--- a/display_list/display_list_dispatcher.cc
+++ b/display_list/display_list_dispatcher.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/trace_event.h"
 #include "impeller/entity/contents/linear_gradient_contents.h"
+#include "impeller/entity/entity.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
 #include "third_party/skia/include/core/SkColor.h"
@@ -158,7 +159,69 @@ void DisplayListDispatcher::setInvertColors(bool invert) {
 
 // |flutter::Dispatcher|
 void DisplayListDispatcher::setBlendMode(SkBlendMode mode) {
-  UNIMPLEMENTED;
+  switch (mode) {
+    case SkBlendMode::kClear:
+      paint_.blend_mode = Entity::BlendMode::kClear;
+      break;
+    case SkBlendMode::kSrc:
+      paint_.blend_mode = Entity::BlendMode::kSource;
+      break;
+    case SkBlendMode::kDst:
+      paint_.blend_mode = Entity::BlendMode::kDestination;
+      break;
+    case SkBlendMode::kSrcOver:
+      paint_.blend_mode = Entity::BlendMode::kSourceOver;
+      break;
+    case SkBlendMode::kDstOver:
+      paint_.blend_mode = Entity::BlendMode::kDestinationOver;
+      break;
+    case SkBlendMode::kSrcIn:
+      paint_.blend_mode = Entity::BlendMode::kSourceIn;
+      break;
+    case SkBlendMode::kDstIn:
+      paint_.blend_mode = Entity::BlendMode::kDestinationIn;
+      break;
+    case SkBlendMode::kSrcOut:
+      paint_.blend_mode = Entity::BlendMode::kSourceOut;
+      break;
+    case SkBlendMode::kDstOut:
+      paint_.blend_mode = Entity::BlendMode::kDestinationOut;
+      break;
+    case SkBlendMode::kSrcATop:
+      paint_.blend_mode = Entity::BlendMode::kSourceATop;
+      break;
+    case SkBlendMode::kDstATop:
+      paint_.blend_mode = Entity::BlendMode::kDestinationATop;
+      break;
+    case SkBlendMode::kXor:
+      paint_.blend_mode = Entity::BlendMode::kXor;
+      break;
+    case SkBlendMode::kPlus:
+      paint_.blend_mode = Entity::BlendMode::kPlus;
+      break;
+    case SkBlendMode::kModulate:
+      paint_.blend_mode = Entity::BlendMode::kModulate;
+      break;
+    case SkBlendMode::kScreen:
+    case SkBlendMode::kOverlay:
+    case SkBlendMode::kDarken:
+    case SkBlendMode::kLighten:
+    case SkBlendMode::kColorDodge:
+    case SkBlendMode::kColorBurn:
+    case SkBlendMode::kHardLight:
+    case SkBlendMode::kSoftLight:
+    case SkBlendMode::kDifference:
+    case SkBlendMode::kExclusion:
+    case SkBlendMode::kMultiply:
+    case SkBlendMode::kHue:
+    case SkBlendMode::kSaturation:
+    case SkBlendMode::kColor:
+    case SkBlendMode::kLuminosity:
+      // Non-pipeline-friendly blend modes are not supported by setBlendMode
+      // yet.
+      UNIMPLEMENTED;
+      break;
+  }
 }
 
 // |flutter::Dispatcher|

--- a/entity/contents/clear_contents.cc
+++ b/entity/contents/clear_contents.cc
@@ -28,8 +28,6 @@ bool ClearContents::Render(const ContentContext& renderer,
   Entity clear_entity = entity;
   clear_entity.SetPath(
       PathBuilder{}.AddRect(Size(pass.GetRenderTargetSize())).TakePath());
-  // Set blend mode to overwrite the destination.
-  clear_entity.SetBlendMode(Entity::BlendMode::kSource);
   return contents_->Render(renderer, clear_entity, pass);
 }
 

--- a/entity/contents/clear_contents.cc
+++ b/entity/contents/clear_contents.cc
@@ -28,6 +28,8 @@ bool ClearContents::Render(const ContentContext& renderer,
   Entity clear_entity = entity;
   clear_entity.SetPath(
       PathBuilder{}.AddRect(Size(pass.GetRenderTargetSize())).TakePath());
+  // Set blend mode to overwrite the destination.
+  clear_entity.SetBlendMode(Entity::BlendMode::kSource);
   return contents_->Render(renderer, clear_entity, pass);
 }
 

--- a/entity/contents/clip_contents.cc
+++ b/entity/contents/clip_contents.cc
@@ -27,7 +27,8 @@ bool ClipContents::Render(const ContentContext& renderer,
 
   Command cmd;
   cmd.label = "Clip";
-  cmd.pipeline = renderer.GetClipPipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetClipPipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(SolidColorContents::CreateSolidFillVertices(
       entity.GetPath(), pass.GetTransientsBuffer()));
@@ -59,7 +60,8 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
 
   Command cmd;
   cmd.label = "Clip Restore";
-  cmd.pipeline = renderer.GetClipRestorePipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetClipRestorePipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
 
   // Create a rect that covers the whole render target.

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -15,6 +15,14 @@ ContentContextOptions OptionsFromPass(const RenderPass& pass) {
   return opts;
 }
 
+ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
+                                               const Entity& entity) {
+  ContentContextOptions opts;
+  opts.sample_count = pass.GetRenderTarget().GetSampleCount();
+  opts.blend_mode = entity.GetBlendMode();
+  return opts;
+}
+
 Contents::Contents() = default;
 
 Contents::~Contents() = default;

--- a/entity/contents/contents.h
+++ b/entity/contents/contents.h
@@ -20,6 +20,9 @@ class RenderPass;
 
 ContentContextOptions OptionsFromPass(const RenderPass& pass);
 
+ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
+                                               const Entity& entity);
+
 class Contents {
  public:
   Contents();

--- a/entity/contents/linear_gradient_contents.cc
+++ b/entity/contents/linear_gradient_contents.cc
@@ -66,7 +66,8 @@ bool LinearGradientContents::Render(const ContentContext& renderer,
 
   Command cmd;
   cmd.label = "LinearGradientFill";
-  cmd.pipeline = renderer.GetGradientFillPipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetGradientFillPipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(
       vertices_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));

--- a/entity/contents/solid_color_contents.cc
+++ b/entity/contents/solid_color_contents.cc
@@ -54,7 +54,8 @@ bool SolidColorContents::Render(const ContentContext& renderer,
 
   Command cmd;
   cmd.label = "SolidFill";
-  cmd.pipeline = renderer.GetSolidFillPipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetSolidFillPipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(
       CreateSolidFillVertices(entity.GetPath(), pass.GetTransientsBuffer()));

--- a/entity/contents/solid_stroke_contents.cc
+++ b/entity/contents/solid_stroke_contents.cc
@@ -149,7 +149,8 @@ bool SolidStrokeContents::Render(const ContentContext& renderer,
   Command cmd;
   cmd.primitive_type = PrimitiveType::kTriangleStrip;
   cmd.label = "SolidStroke";
-  cmd.pipeline = renderer.GetSolidStrokePipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetSolidStrokePipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(CreateSolidStrokeVertices(
       entity.GetPath(), pass.GetTransientsBuffer(), cap_proc_, join_proc_,

--- a/entity/contents/text_contents.cc
+++ b/entity/contents/text_contents.cc
@@ -48,7 +48,8 @@ bool TextContents::Render(const ContentContext& renderer,
   Command cmd;
   cmd.label = "Glyph";
   cmd.primitive_type = PrimitiveType::kTriangle;
-  cmd.pipeline = renderer.GetGlyphAtlasPipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetGlyphAtlasPipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
 
   // Common vertex uniforms for all glyphs.

--- a/entity/contents/texture_contents.cc
+++ b/entity/contents/texture_contents.cc
@@ -91,7 +91,8 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   Command cmd;
   cmd.label = "TextureFill";
-  cmd.pipeline = renderer.GetTexturePipeline(OptionsFromPass(pass));
+  cmd.pipeline =
+      renderer.GetTexturePipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
   VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -65,6 +65,14 @@ void Entity::IncrementStencilDepth(uint32_t increment) {
   stencil_depth_ += increment;
 }
 
+void Entity::SetBlendMode(Entity::BlendMode blend_mode) {
+  blend_mode_ = blend_mode;
+}
+
+Entity::BlendMode Entity::GetBlendMode() const {
+  return blend_mode_;
+}
+
 bool Entity::Render(const ContentContext& renderer,
                     RenderPass& parent_pass) const {
   if (!contents_) {

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/entity/entity.h"
 
+#include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/renderer/render_pass.h"
 
@@ -66,6 +67,10 @@ void Entity::IncrementStencilDepth(uint32_t increment) {
 }
 
 void Entity::SetBlendMode(Entity::BlendMode blend_mode) {
+  if (blend_mode_ > BlendMode::kLastPipelineBlendMode) {
+    VALIDATION_LOG << "Non-pipeline blend modes are not supported by the "
+                      "entity blend mode setting.";
+  }
   blend_mode_ = blend_mode;
 }
 

--- a/entity/entity.h
+++ b/entity/entity.h
@@ -76,11 +76,16 @@ class Entity {
 
   uint32_t GetStencilDepth() const;
 
+  void SetBlendMode(Entity::BlendMode blend_mode);
+
+  Entity::BlendMode GetBlendMode() const;
+
   bool Render(const ContentContext& renderer, RenderPass& parent_pass) const;
 
  private:
   Matrix transformation_;
   std::shared_ptr<Contents> contents_;
+  Entity::BlendMode blend_mode_ = Entity::BlendMode::kSourceOver;
   Path path_;
   uint32_t stencil_depth_ = 0u;
   bool adds_to_coverage_ = true;

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -715,5 +715,12 @@ TEST_F(EntityTest, GaussianBlurFilter) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
+TEST_F(EntityTest, SetBlendMode) {
+  Entity entity;
+  ASSERT_EQ(entity.GetBlendMode(), Entity::BlendMode::kSourceOver);
+  entity.SetBlendMode(Entity::BlendMode::kClear);
+  ASSERT_EQ(entity.GetBlendMode(), Entity::BlendMode::kClear);
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/919017/158885793-d169d255-cb95-48e0-b2d0-4ad4f75bc992.png)

@chinmaygarde FYI, I was going to make ClearContents use kSource, but the docs say it should respect the blend mode. I think ClearContents should maybe be called something else (perhaps "ExpandContents" or "CoverContents"?), since I don't think drawPaint is supposed to overwrite the destination if the paint is transparent.