### PR TITLE
Apply Aiks transforms in the canvas space, not world space

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -132,9 +132,7 @@ TEST_F(AiksTest, ClipsUseCurrentTransform) {
 
   canvas.Translate(Vector3(300, 300));
   for (int i = 0; i < 15; i++) {
-    canvas.Translate(-Vector3(300, 300));
     canvas.Scale(Vector3(0.8, 0.8));
-    canvas.Translate(Vector3(300, 300));
 
     paint.color = colors[i % colors.size()];
     canvas.ClipPath(PathBuilder{}.AddCircle({0, 0}, 300).TakePath());
@@ -202,7 +200,7 @@ TEST_F(AiksTest, CanPerformSkew) {
   Paint red;
   red.color = Color::Red();
 
-  canvas.Skew(10, 125);
+  canvas.Skew(2, 5);
   canvas.DrawRect(Rect::MakeXYWH(0, 0, 100, 100), red);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
@@ -415,6 +413,44 @@ TEST_F(AiksTest, PaintBlendModeIsRespected) {
   paint.color = Color::Blue();
   canvas.DrawCircle(Point(500, 150), 100, paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_F(AiksTest, TransformMultipliesCorrectly) {
+  Canvas canvas;
+  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(), Matrix());
+
+  // clang-format off
+  canvas.Translate(Vector3(100, 200));
+  ASSERT_MATRIX_NEAR(
+    canvas.GetCurrentTransformation(),
+    Matrix(  1,   0,   0,   0,
+             0,   1,   0,   0,
+             0,   0,   1,   0,
+           100, 200,   0,   1));
+
+  canvas.Rotate(Radians(kPiOver2));
+  ASSERT_MATRIX_NEAR(
+    canvas.GetCurrentTransformation(),
+    Matrix(  0,   1,   0,   0,
+            -1,   0,   0,   0,
+             0,   0,   1,   0,
+           100, 200,   0,   1));
+
+  canvas.Scale(Vector3(2, 3));
+  ASSERT_MATRIX_NEAR(
+    canvas.GetCurrentTransformation(),
+    Matrix(  0,   2,   0,   0,
+            -3,   0,   0,   0,
+             0,   0,   0,   0,
+           100, 200,   0,   1));
+
+  canvas.Translate(Vector3(100, 200));
+  ASSERT_MATRIX_NEAR(
+    canvas.GetCurrentTransformation(),
+    Matrix(   0,   2,   0,   0,
+             -3,   0,   0,   0,
+              0,   0,   0,   0,
+           -500, 400,   0,   1));
 }
 
 }  // namespace testing

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -61,7 +61,7 @@ bool Canvas::Restore() {
 }
 
 void Canvas::Concat(const Matrix& xformation) {
-  xformation_stack_.back().xformation = xformation * GetCurrentTransformation();
+  xformation_stack_.back().xformation = GetCurrentTransformation() * xformation;
 }
 
 void Canvas::ResetTransform() {


### PR DESCRIPTION
This fixes the transform for everything except the background in the [page flip example](https://github.com/bizz84/page_flip_builder). I don't see any more transform-related issues in either page flip or gallery.