### PR TITLE
Make the filter DAG render all textures at the correct resolution

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -442,6 +442,7 @@ TEST_F(AiksTest, TransformMultipliesCorrectly) {
              -3,   0,   0,   0,
               0,   0,   0,   0,
            -500, 400,   0,   1));
+  // clang-format on
 }
 
 }  // namespace testing

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -27,4 +27,13 @@ Contents::Contents() = default;
 
 Contents::~Contents() = default;
 
+Rect Contents::GetBounds(const Entity& entity) const {
+  const auto& transform = entity.GetTransformation();
+  auto points = entity.GetPath().GetBoundingBox()->GetPoints();
+  for (uint i = 0; i < points.size(); i++) {
+    points[i] = transform * points[i];
+  }
+  return Rect::MakePointBounds(points);
+}
+
 }  // namespace impeller

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 #include "impeller/entity/contents/contents.h"
+#include <optional>
 
 #include "impeller/entity/contents/content_context.h"
+#include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
 
 namespace impeller {
@@ -27,10 +29,6 @@ Contents::Contents() = default;
 
 Contents::~Contents() = default;
 
-bool Contents::IsFilter() const {
-  return false;
-}
-
 Rect Contents::GetBounds(const Entity& entity) const {
   const auto& transform = entity.GetTransformation();
   auto points = entity.GetPath().GetBoundingBox()->GetPoints();
@@ -38,6 +36,72 @@ Rect Contents::GetBounds(const Entity& entity) const {
     points[i] = transform * points[i];
   }
   return Rect::MakePointBounds({points.begin(), points.end()});
+}
+
+std::optional<Contents::Snapshot> Contents::RenderToTexture(
+    const ContentContext& renderer,
+    const Entity& entity) const {
+  auto bounds = GetBounds(entity);
+
+  auto texture = MakeSubpass(
+      renderer, ISize(bounds.size),
+      [&contents = *this, &entity, &bounds](const ContentContext& renderer,
+                                            RenderPass& pass) -> bool {
+        Entity sub_entity;
+        sub_entity.SetPath(entity.GetPath());
+        sub_entity.SetBlendMode(Entity::BlendMode::kSource);
+        sub_entity.SetTransformation(
+            Matrix::MakeTranslation(Vector3(-bounds.origin)) *
+            entity.GetTransformation());
+        return contents.Render(renderer, sub_entity, pass);
+      });
+
+  if (!texture.has_value()) {
+    return std::nullopt;
+  }
+
+  return Snapshot{.texture = texture.value(), .position = bounds.origin};
+}
+
+using SubpassCallback = std::function<bool(const ContentContext&, RenderPass&)>;
+
+std::optional<std::shared_ptr<Texture>> Contents::MakeSubpass(
+    const ContentContext& renderer,
+    ISize texture_size,
+    SubpassCallback subpass_callback) {
+  auto context = renderer.GetContext();
+
+  auto subpass_target = RenderTarget::CreateOffscreen(*context, texture_size);
+  auto subpass_texture = subpass_target.GetRenderTargetTexture();
+  if (!subpass_texture) {
+    return std::nullopt;
+  }
+
+  auto sub_command_buffer = context->CreateRenderCommandBuffer();
+  sub_command_buffer->SetLabel("Offscreen Contents Command Buffer");
+  if (!sub_command_buffer) {
+    return std::nullopt;
+  }
+
+  auto sub_renderpass = sub_command_buffer->CreateRenderPass(subpass_target);
+  if (!sub_renderpass) {
+    return std::nullopt;
+  }
+  sub_renderpass->SetLabel("OffscreenContentsPass");
+
+  if (!subpass_callback(renderer, *sub_renderpass)) {
+    return std::nullopt;
+  }
+
+  if (!sub_renderpass->EncodeCommands(*context->GetTransientsAllocator())) {
+    return std::nullopt;
+  }
+
+  if (!sub_command_buffer->SubmitCommands()) {
+    return std::nullopt;
+  }
+
+  return subpass_texture;
 }
 
 }  // namespace impeller

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -37,7 +37,7 @@ Rect Contents::GetBounds(const Entity& entity) const {
   for (uint i = 0; i < points.size(); i++) {
     points[i] = transform * points[i];
   }
-  return Rect::MakePointBounds(points);
+  return Rect::MakePointBounds({points.begin(), points.end()});
 }
 
 }  // namespace impeller

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -27,6 +27,10 @@ Contents::Contents() = default;
 
 Contents::~Contents() = default;
 
+bool Contents::IsFilter() const {
+  return false;
+}
+
 Rect Contents::GetBounds(const Entity& entity) const {
   const auto& transform = entity.GetTransformation();
   auto points = entity.GetPath().GetBoundingBox()->GetPoints();

--- a/entity/contents/contents.h
+++ b/entity/contents/contents.h
@@ -34,6 +34,10 @@ class Contents {
                       const Entity& entity,
                       RenderPass& pass) const = 0;
 
+  /// @brief Returns true if this Contents is a FilterContents. This is useful
+  ///        for downcasting to FilterContents without RTTI.
+  virtual bool IsFilter() const;
+
   /// @brief Get the bounding rectangle that this contents modifies in screen
   ///        space.
   virtual Rect GetBounds(const Entity& entity) const;

--- a/entity/contents/contents.h
+++ b/entity/contents/contents.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/renderer/texture.h"
 
 namespace impeller {
 
@@ -26,6 +27,14 @@ ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
 
 class Contents {
  public:
+  /// Represents a screen space texture and it's intended draw position.
+  struct Snapshot {
+    std::shared_ptr<Texture> texture;
+    /// The offset from the origin where this texture is intended to be
+    /// rendered.
+    Vector2 position;
+  };
+
   Contents();
 
   virtual ~Contents();
@@ -34,13 +43,25 @@ class Contents {
                       const Entity& entity,
                       RenderPass& pass) const = 0;
 
-  /// @brief Returns true if this Contents is a FilterContents. This is useful
-  ///        for downcasting to FilterContents without RTTI.
-  virtual bool IsFilter() const;
-
   /// @brief Get the bounding rectangle that this contents modifies in screen
   ///        space.
   virtual Rect GetBounds(const Entity& entity) const;
+
+  /// @brief Render this contents to a texture, respecting the entity's
+  ///        transform, path, stencil depth, blend mode, etc.
+  ///        The result texture size is always the size of `GetBounds(entity)`.
+  virtual std::optional<Snapshot> RenderToTexture(
+      const ContentContext& renderer,
+      const Entity& entity) const;
+
+  using SubpassCallback =
+      std::function<bool(const ContentContext&, RenderPass&)>;
+  static std::optional<std::shared_ptr<Texture>> MakeSubpass(
+      const ContentContext& renderer,
+      ISize texture_size,
+      SubpassCallback subpass_callback);
+
+ protected:
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(Contents);

--- a/entity/contents/contents.h
+++ b/entity/contents/contents.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "flutter/fml/macros.h"
+#include "impeller/geometry/rect.h"
 
 namespace impeller {
 
@@ -32,6 +33,10 @@ class Contents {
   virtual bool Render(const ContentContext& renderer,
                       const Entity& entity,
                       RenderPass& pass) const = 0;
+
+  /// @brief Get the bounding rectangle that this contents modifies in screen
+  ///        space.
+  virtual Rect GetBounds(const Entity& entity) const;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(Contents);

--- a/entity/contents/filters/blend_filter_contents.cc
+++ b/entity/contents/filters/blend_filter_contents.cc
@@ -20,16 +20,9 @@ using PipelineProc =
     std::shared_ptr<Pipeline> (ContentContext::*)(ContentContextOptions) const;
 
 template <typename VS, typename FS>
-static void AdvancedBlendPass(std::shared_ptr<Texture> input_d,
-                              std::shared_ptr<Texture> input_s,
-                              std::shared_ptr<const Sampler> sampler,
-                              const ContentContext& renderer,
-                              RenderPass& pass,
-                              Command& cmd) {}
-
-template <typename VS, typename FS>
 static bool AdvancedBlend(
-    const std::vector<std::shared_ptr<Texture>>& input_textures,
+    const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+        input_textures,
     const ContentContext& renderer,
     RenderPass& pass,
     PipelineProc pipeline_proc) {
@@ -39,22 +32,17 @@ static bool AdvancedBlend(
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
+  auto size = pass.GetRenderTargetSize();
   VertexBufferBuilder<typename VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
       {Point(0, 0), Point(0, 0)},
-      {Point(1, 0), Point(1, 0)},
-      {Point(1, 1), Point(1, 1)},
+      {Point(size.width, 0), Point(1, 0)},
+      {Point(size.width, size.height), Point(1, 1)},
       {Point(0, 0), Point(0, 0)},
-      {Point(1, 1), Point(1, 1)},
-      {Point(0, 1), Point(0, 1)},
+      {Point(size.width, size.height), Point(1, 1)},
+      {Point(0, size.height), Point(0, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-
-  typename VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-
-  auto uniform_view = host_buffer.EmplaceUniform(frame_info);
-  auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = Entity::BlendMode::kSource;
@@ -65,10 +53,21 @@ static bool AdvancedBlend(
   cmd.label = "Advanced Blend Filter";
   cmd.BindVertices(vtx_buffer);
   cmd.pipeline = std::move(pipeline);
-  VS::BindFrameInfo(cmd, uniform_view);
 
-  FS::BindTextureSamplerDst(cmd, input_textures[0], sampler);
-  FS::BindTextureSamplerSrc(cmd, input_textures[1], sampler);
+  auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+  typename VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(size);
+
+  auto [dst_texture, dst_offset] = input_textures[1];
+  FS::BindTextureSamplerSrc(cmd, dst_texture, sampler);
+  frame_info.dst_uv_offset = dst_offset / size;
+
+  auto [src_texture, src_offset] = input_textures[0];
+  FS::BindTextureSamplerDst(cmd, src_texture, sampler);
+  frame_info.src_uv_offset = src_offset / size;
+
+  auto uniform_view = host_buffer.EmplaceUniform(frame_info);
+  VS::BindFrameInfo(cmd, uniform_view);
   pass.AddCommand(cmd);
 
   return true;
@@ -89,7 +88,8 @@ void BlendFilterContents::SetBlendMode(Entity::BlendMode blend_mode) {
     switch (blend_mode) {
       case Entity::BlendMode::kScreen:
         advanced_blend_proc_ =
-            [](const std::vector<std::shared_ptr<Texture>>& input_textures,
+            [](const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+                   input_textures,
                const ContentContext& renderer, RenderPass& pass) {
               PipelineProc p = &ContentContext::GetTextureBlendScreenPipeline;
               return AdvancedBlend<TextureBlendScreenPipeline::VertexShader,
@@ -104,7 +104,8 @@ void BlendFilterContents::SetBlendMode(Entity::BlendMode blend_mode) {
 }
 
 static bool BasicBlend(
-    const std::vector<std::shared_ptr<Texture>>& input_textures,
+    const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+        input_textures,
     const ContentContext& renderer,
     RenderPass& pass,
     Entity::BlendMode basic_blend) {
@@ -113,21 +114,18 @@ static bool BasicBlend(
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
+  auto size = pass.GetRenderTargetSize();
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
       {Point(0, 0), Point(0, 0)},
-      {Point(1, 0), Point(1, 0)},
-      {Point(1, 1), Point(1, 1)},
+      {Point(size.width, 0), Point(1, 0)},
+      {Point(size.width, size.height), Point(1, 1)},
       {Point(0, 0), Point(0, 0)},
-      {Point(1, 1), Point(1, 1)},
-      {Point(0, 1), Point(0, 1)},
+      {Point(size.width, size.height), Point(1, 1)},
+      {Point(0, size.height), Point(0, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
-  VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-
-  auto uniform_view = host_buffer.EmplaceUniform(frame_info);
   auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
 
   // Draw the first texture using kSource.
@@ -138,8 +136,17 @@ static bool BasicBlend(
   auto options = OptionsFromPass(pass);
   options.blend_mode = Entity::BlendMode::kSource;
   cmd.pipeline = renderer.GetTextureBlendPipeline(options);
-  FS::BindTextureSamplerSrc(cmd, input_textures[0], sampler);
-  VS::BindFrameInfo(cmd, uniform_view);
+  {
+    auto [texture, offset] = input_textures[0];
+    FS::BindTextureSamplerSrc(cmd, texture, sampler);
+
+    VS::FrameInfo frame_info;
+    frame_info.mvp =
+        Matrix::MakeTranslation(offset) * Matrix::MakeOrthographic(size);
+
+    auto uniform_view = host_buffer.EmplaceUniform(frame_info);
+    VS::BindFrameInfo(cmd, uniform_view);
+  }
   pass.AddCommand(cmd);
 
   if (input_textures.size() < 2) {
@@ -153,7 +160,15 @@ static bool BasicBlend(
 
   for (auto texture_i = input_textures.begin() + 1;
        texture_i < input_textures.end(); texture_i++) {
-    FS::BindTextureSamplerSrc(cmd, *texture_i, sampler);
+    auto [texture, offset] = *texture_i;
+    FS::BindTextureSamplerSrc(cmd, texture, sampler);
+
+    VS::FrameInfo frame_info;
+    frame_info.mvp =
+        Matrix::MakeTranslation(offset) * Matrix::MakeOrthographic(size);
+
+    auto uniform_view = host_buffer.EmplaceUniform(frame_info);
+    VS::BindFrameInfo(cmd, uniform_view);
     pass.AddCommand(cmd);
   }
 
@@ -161,7 +176,8 @@ static bool BasicBlend(
 }
 
 bool BlendFilterContents::RenderFilter(
-    const std::vector<std::shared_ptr<Texture>>& input_textures,
+    const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+        input_textures,
     const ContentContext& renderer,
     RenderPass& pass) const {
   if (input_textures.empty()) {

--- a/entity/contents/filters/blend_filter_contents.h
+++ b/entity/contents/filters/blend_filter_contents.h
@@ -11,7 +11,7 @@ namespace impeller {
 class BlendFilterContents : public FilterContents {
  public:
   using AdvancedBlendProc = std::function<bool(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
           input_textures,
       const ContentContext& renderer,
       RenderPass& pass)>;
@@ -25,10 +25,11 @@ class BlendFilterContents : public FilterContents {
  private:
   // |FilterContents|
   bool RenderFilter(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
           input_textures,
       const ContentContext& renderer,
-      RenderPass& pass) const override;
+      RenderPass& pass,
+      const Matrix& transform) const override;
 
   Entity::BlendMode blend_mode_;
   AdvancedBlendProc advanced_blend_proc_;

--- a/entity/contents/filters/blend_filter_contents.h
+++ b/entity/contents/filters/blend_filter_contents.h
@@ -10,11 +10,10 @@ namespace impeller {
 
 class BlendFilterContents : public FilterContents {
  public:
-  using AdvancedBlendProc = std::function<bool(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
-          input_textures,
-      const ContentContext& renderer,
-      RenderPass& pass)>;
+  using AdvancedBlendProc =
+      std::function<bool(const std::vector<Snapshot>& input_textures,
+                         const ContentContext& renderer,
+                         RenderPass& pass)>;
 
   BlendFilterContents();
 
@@ -24,12 +23,10 @@ class BlendFilterContents : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
-          input_textures,
-      const ContentContext& renderer,
-      RenderPass& pass,
-      const Matrix& transform) const override;
+  bool RenderFilter(const std::vector<Snapshot>& input_textures,
+                    const ContentContext& renderer,
+                    RenderPass& pass,
+                    const Matrix& transform) const override;
 
   Entity::BlendMode blend_mode_;
   AdvancedBlendProc advanced_blend_proc_;

--- a/entity/contents/filters/blend_filter_contents.h
+++ b/entity/contents/filters/blend_filter_contents.h
@@ -11,7 +11,8 @@ namespace impeller {
 class BlendFilterContents : public FilterContents {
  public:
   using AdvancedBlendProc = std::function<bool(
-      const std::vector<std::shared_ptr<Texture>>& input_textures,
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+          input_textures,
       const ContentContext& renderer,
       RenderPass& pass)>;
 
@@ -23,9 +24,11 @@ class BlendFilterContents : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(const std::vector<std::shared_ptr<Texture>>& input_textures,
-                    const ContentContext& renderer,
-                    RenderPass& pass) const override;
+  bool RenderFilter(
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+          input_textures,
+      const ContentContext& renderer,
+      RenderPass& pass) const override;
 
   Entity::BlendMode blend_mode_;
   AdvancedBlendProc advanced_blend_proc_;

--- a/entity/contents/filters/filter_contents.cc
+++ b/entity/contents/filters/filter_contents.cc
@@ -125,7 +125,7 @@ Rect FilterContents::GetBoundsForInput(const Entity& entity,
     for (uint i = 0; i < points.size(); i++) {
       points[i] = transform * points[i];
     }
-    return Rect::MakePointBounds(points);
+    return Rect::MakePointBounds({points.begin(), points.end()});
   }
 
   FML_UNREACHABLE();

--- a/entity/contents/filters/filter_contents.cc
+++ b/entity/contents/filters/filter_contents.cc
@@ -192,11 +192,11 @@ static std::optional<std::shared_ptr<Texture>> MakeSubpass(
 }
 
 static std::optional<std::tuple<std::shared_ptr<Texture>, Point>>
-RenderInputToTexture(const ContentContext& renderer,
-                     const Entity& entity,
-                     RenderPass& pass,
-                     Size pass_size,
-                     FilterContents::InputVariant input) {
+ResolveTextureForInput(const ContentContext& renderer,
+                       const Entity& entity,
+                       RenderPass& pass,
+                       Size pass_size,
+                       FilterContents::InputVariant input) {
   auto input_bounds = FilterContents::GetBoundsForInput(entity, input);
   Point draw_offset = input_bounds.origin - input_bounds.origin;
 
@@ -253,7 +253,7 @@ std::optional<std::shared_ptr<Texture>> FilterContents::RenderFilterToTexture(
   input_textures.reserve(input_textures_.size());
   for (const auto& input : input_textures_) {
     auto texture_and_offset =
-        RenderInputToTexture(renderer, entity, pass, bounds.size, input);
+        ResolveTextureForInput(renderer, entity, pass, bounds.size, input);
     if (!texture_and_offset.has_value()) {
       continue;
     }

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -48,9 +48,6 @@ class FilterContents : public Contents {
   void SetInputTextures(InputTextures input_textures);
 
   // |Contents|
-  bool IsFilter() const override;
-
-  // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;
@@ -58,22 +55,18 @@ class FilterContents : public Contents {
   // |Contents|
   Rect GetBounds(const Entity& entity) const override;
 
-  /// @brief Renders dependency filters, creates a subpass, and calls the
-  ///        `RenderFilter` defined by the subclasses.
-  std::optional<std::shared_ptr<Texture>> RenderFilterToTexture(
+  // |Contents|
+  virtual std::optional<Snapshot> RenderToTexture(
       const ContentContext& renderer,
-      const Entity& entity,
-      RenderPass& pass) const;
+      const Entity& entity) const override;
 
  private:
   /// @brief Takes a set of zero or more input textures and writes to an output
   ///        texture.
-  virtual bool RenderFilter(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
-          input_textures,
-      const ContentContext& renderer,
-      RenderPass& pass,
-      const Matrix& transform) const = 0;
+  virtual bool RenderFilter(const std::vector<Snapshot>& input_textures,
+                            const ContentContext& renderer,
+                            RenderPass& pass,
+                            const Matrix& transform) const = 0;
 
   InputTextures input_textures_;
   Rect destination_;

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -53,6 +53,9 @@ class FilterContents : public Contents {
               const Entity& entity,
               RenderPass& pass) const override;
 
+  // |Contents|
+  Rect GetBounds(const Entity& entity) const override;
+
   /// @brief Renders dependency filters, creates a subpass, and calls the
   ///        `RenderFilter` defined by the subclasses.
   std::optional<std::shared_ptr<Texture>> RenderFilterToTexture(

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -69,10 +69,11 @@ class FilterContents : public Contents {
   /// @brief Takes a set of zero or more input textures and writes to an output
   ///        texture.
   virtual bool RenderFilter(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
           input_textures,
       const ContentContext& renderer,
-      RenderPass& pass) const = 0;
+      RenderPass& pass,
+      const Matrix& transform) const = 0;
 
   InputTextures input_textures_;
   Rect destination_;

--- a/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 #include "impeller/entity/contents/filters/gaussian_blur_filter_contents.h"
+
 #include <valarray>
 
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/geometry/scalar.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/sampler_library.h"
 
@@ -20,16 +22,15 @@ DirectionalGaussianBlurFilterContents::
     ~DirectionalGaussianBlurFilterContents() = default;
 
 void DirectionalGaussianBlurFilterContents::SetBlurVector(Vector2 blur_vector) {
-  if (blur_vector.GetLengthSquared() < 1e-3f) {
-    blur_vector_ = Vector2(0, 1e-3f);
+  if (blur_vector.GetLengthSquared() < kEhCloseEnough) {
+    blur_vector_ = Vector2(0, kEhCloseEnough);
     return;
   }
   blur_vector_ = blur_vector;
 }
 
 bool DirectionalGaussianBlurFilterContents::RenderFilter(
-    const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
-        input_textures,
+    const std::vector<Snapshot>& input_textures,
     const ContentContext& renderer,
     RenderPass& pass,
     const Matrix& transform) const {

--- a/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -39,14 +39,24 @@ bool DirectionalGaussianBlurFilterContents::RenderFilter(
   auto& host_buffer = pass.GetTransientsBuffer();
 
   auto size = pass.GetRenderTargetSize();
+  auto uv_offset = blur_vector_ / size;
+
+  // LTRB
+  Scalar uv[4] = {
+      -uv_offset.x,
+      -uv_offset.y,
+      1 + uv_offset.x,
+      1 + uv_offset.y,
+  };
+
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
-      {Point(0, 0), Point(0, 0)},
-      {Point(size.width, 0), Point(1, 0)},
-      {Point(size.width, size.height), Point(1, 1)},
-      {Point(0, 0), Point(0, 0)},
-      {Point(size.width, size.height), Point(1, 1)},
-      {Point(0, size.height), Point(0, 1)},
+      {Point(0, 0), Point(uv[0], uv[1])},
+      {Point(size.width, 0), Point(uv[2], uv[1])},
+      {Point(size.width, size.height), Point(uv[2], uv[3])},
+      {Point(0, 0), Point(uv[0], uv[1])},
+      {Point(size.width, size.height), Point(uv[2], uv[3])},
+      {Point(0, size.height), Point(uv[0], uv[3])},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 

--- a/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 #include "impeller/entity/contents/filters/gaussian_blur_filter_contents.h"
+#include <cmath>
+#include <valarray>
 
 #include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/geometry/rect.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/sampler_library.h"
 
@@ -16,20 +20,17 @@ DirectionalGaussianBlurFilterContents::DirectionalGaussianBlurFilterContents() =
 DirectionalGaussianBlurFilterContents::
     ~DirectionalGaussianBlurFilterContents() = default;
 
-void DirectionalGaussianBlurFilterContents::SetRadius(Scalar radius) {
-  radius_ = std::max(radius, 1e-3f);
-}
-
-void DirectionalGaussianBlurFilterContents::SetDirection(Vector2 direction) {
-  direction_ = direction.Normalize();
-}
-
-void DirectionalGaussianBlurFilterContents::SetClipBorder(bool clip) {
-  clip_ = clip;
+void DirectionalGaussianBlurFilterContents::SetBlurVector(Vector2 blur_vector) {
+  if (blur_vector.GetLengthSquared() < 1e-3f) {
+    blur_vector_ = Vector2(0, 1e-3f);
+    return;
+  }
+  blur_vector_ = blur_vector;
 }
 
 bool DirectionalGaussianBlurFilterContents::RenderFilter(
-    const std::vector<std::shared_ptr<Texture>>& input_textures,
+    const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+        input_textures,
     const ContentContext& renderer,
     RenderPass& pass) const {
   using VS = GaussianBlurPipeline::VertexShader;
@@ -37,34 +38,23 @@ bool DirectionalGaussianBlurFilterContents::RenderFilter(
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  ISize size = FilterContents::GetOutputSize();
-  Point uv_offset = clip_ ? (Point(radius_, radius_) / size) : Point();
-  // LTRB
-  Scalar uv[4] = {
-      -uv_offset.x,
-      -uv_offset.y,
-      1 + uv_offset.x,
-      1 + uv_offset.y,
-  };
-
+  auto size = pass.GetRenderTargetSize();
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
-      {Point(0, 0), Point(uv[0], uv[1])},
-      {Point(size.width, 0), Point(uv[2], uv[1])},
-      {Point(size.width, size.height), Point(uv[2], uv[3])},
-      {Point(0, 0), Point(uv[0], uv[1])},
-      {Point(size.width, size.height), Point(uv[2], uv[3])},
-      {Point(0, size.height), Point(uv[0], uv[3])},
+      {Point(0, 0), Point(0, 0)},
+      {Point(size.width, 0), Point(1, 0)},
+      {Point(size.width, size.height), Point(1, 1)},
+      {Point(0, 0), Point(0, 0)},
+      {Point(size.width, size.height), Point(1, 1)},
+      {Point(0, size.height), Point(0, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(size);
   frame_info.texture_size = Point(size);
-  frame_info.blur_radius = radius_;
-  frame_info.blur_direction = direction_;
+  frame_info.blur_radius = blur_vector_.GetLength();
+  frame_info.blur_direction = blur_vector_.Normalize();
 
-  auto uniform_view = host_buffer.EmplaceUniform(frame_info);
   auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
 
   Command cmd;
@@ -73,29 +63,25 @@ bool DirectionalGaussianBlurFilterContents::RenderFilter(
   options.blend_mode = Entity::BlendMode::kSource;
   cmd.pipeline = renderer.GetGaussianBlurPipeline(options);
   cmd.BindVertices(vtx_buffer);
-  VS::BindFrameInfo(cmd, uniform_view);
-  for (const auto& texture : input_textures) {
+  for (const auto& [texture, offset] : input_textures) {
     FS::BindTextureSampler(cmd, texture, sampler);
+
+    frame_info.mvp =
+        Matrix::MakeTranslation(offset) * Matrix::MakeOrthographic(size);
+    auto uniform_view = host_buffer.EmplaceUniform(frame_info);
+    VS::BindFrameInfo(cmd, uniform_view);
+
     pass.AddCommand(cmd);
   }
 
   return true;
 }
 
-ISize DirectionalGaussianBlurFilterContents::GetOutputSize(
-    const InputTextures& input_textures) const {
-  ISize size;
-  if (auto filter =
-          std::get_if<std::shared_ptr<FilterContents>>(&input_textures[0])) {
-    size = filter->get()->GetOutputSize();
-  } else if (auto texture =
-                 std::get_if<std::shared_ptr<Texture>>(&input_textures[0])) {
-    size = texture->get()->GetSize();
-  } else {
-    FML_UNREACHABLE();
-  }
-
-  return size + (clip_ ? ISize(radius_ * 2, radius_ * 2) : ISize());
+Rect DirectionalGaussianBlurFilterContents::GetBounds(
+    const Entity& entity) const {
+  auto bounds = FilterContents::GetBounds(entity);
+  auto extent = bounds.size + blur_vector_ * 2;
+  return Rect(bounds.origin - blur_vector_, Size(extent.x, extent.y));
 }
 
 }  // namespace impeller

--- a/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/geometry/matrix.h"
 
 namespace impeller {
 
@@ -22,10 +23,11 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
  private:
   // |FilterContents|
   bool RenderFilter(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
           input_textures,
       const ContentContext& renderer,
-      RenderPass& pass) const override;
+      RenderPass& pass,
+      const Matrix& transform) const override;
 
   Vector2 blur_vector_;
 

--- a/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -14,25 +14,20 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
 
   ~DirectionalGaussianBlurFilterContents() override;
 
-  void SetRadius(Scalar radius);
+  void SetBlurVector(Vector2 blur_vector);
 
-  void SetDirection(Vector2 direction);
-
-  void SetClipBorder(bool clip);
+  // |Contents|
+  Rect GetBounds(const Entity& entity) const override;
 
  private:
   // |FilterContents|
-  bool RenderFilter(const std::vector<std::shared_ptr<Texture>>& input_textures,
-                    const ContentContext& renderer,
-                    RenderPass& pass) const override;
+  bool RenderFilter(
+      const std::vector<std::tuple<std::shared_ptr<Texture>, Point>>&
+          input_textures,
+      const ContentContext& renderer,
+      RenderPass& pass) const override;
 
-  // |FilterContents|
-  virtual ISize GetOutputSize(
-      const InputTextures& input_textures) const override;
-
-  Scalar radius_ = 0;
-  Vector2 direction_;
-  bool clip_ = false;
+  Vector2 blur_vector_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(DirectionalGaussianBlurFilterContents);
 };

--- a/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -22,12 +22,10 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(
-      const std::vector<std::tuple<std::shared_ptr<Texture>, Rect>>&
-          input_textures,
-      const ContentContext& renderer,
-      RenderPass& pass,
-      const Matrix& transform) const override;
+  bool RenderFilter(const std::vector<Snapshot>& input_textures,
+                    const ContentContext& renderer,
+                    RenderPass& pass,
+                    const Matrix& transform) const override;
 
   Vector2 blur_vector_;
 

--- a/entity/contents/texture_contents.h
+++ b/entity/contents/texture_contents.h
@@ -10,7 +10,6 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/contents.h"
-#include "impeller/geometry/rect.h"
 
 namespace impeller {
 

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -39,11 +39,11 @@ bool Entity::AddsToCoverage() const {
 }
 
 std::optional<Rect> Entity::GetCoverage() const {
-  if (!adds_to_coverage_) {
+  if (!adds_to_coverage_ || !contents_) {
     return std::nullopt;
   }
 
-  return path_.GetBoundingBox();
+  return contents_->GetBounds(*this);
 }
 
 void Entity::SetContents(std::shared_ptr<Contents> contents) {

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -681,22 +681,24 @@ TEST_F(EntityTest, GaussianBlurFilter) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     if (first_frame) {
       first_frame = false;
-      ImGui::SetNextWindowSize({450, 150});
-      ImGui::SetNextWindowPos({200, 450});
+      ImGui::SetNextWindowSize({500, 170});
+      ImGui::SetNextWindowPos({300, 550});
     }
 
     ImGui::Begin("Controls");
+    static float blur_amount[2] = {20, 20};
+    ImGui::SliderFloat2("Blur", &blur_amount[0], 0, 200);
+    static Color cover_color(1, 0, 0, 0.2);
+    ImGui::ColorEdit4("Cover color", reinterpret_cast<float*>(&cover_color));
     static float offset[2] = {500, 400};
     ImGui::SliderFloat2("Translation", &offset[0], 0,
                         pass.GetRenderTargetSize().width);
     static float rotation = 0;
     ImGui::SliderFloat("Rotation", &rotation, 0, kPi * 2);
-    static float scale[2] = {1, 1};
+    static float scale[2] = {0.8, 0.8};
     ImGui::SliderFloat2("Scale", &scale[0], 0, 3);
     static float skew[2] = {0, 0};
     ImGui::SliderFloat2("Skew", &skew[0], -3, 3);
-    static float blur_amount[2] = {20, 20};
-    ImGui::SliderFloat2("Blur", &blur_amount[0], 0, 200);
     ImGui::End();
 
     auto blend = FilterContents::MakeBlend(Entity::BlendMode::kPlus,
@@ -716,12 +718,16 @@ TEST_F(EntityTest, GaussianBlurFilter) {
     entity.SetContents(blur);
     entity.SetTransformation(ctm);
 
+    entity.Render(context, pass);
+
+    // The following entity renders the expected transformed input.
     Entity cover_entity;
     cover_entity.SetPath(PathBuilder{}.AddRect(rect).TakePath());
-    cover_entity.SetContents(SolidColorContents::Make(Color(1, 0, 0, 0.5)));
+    cover_entity.SetContents(SolidColorContents::Make(cover_color));
     cover_entity.SetTransformation(ctm);
 
-    return entity.Render(context, pass) && cover_entity.Render(context, pass);
+    cover_entity.Render(context, pass);
+    return true;
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -690,25 +690,24 @@ TEST_F(EntityTest, GaussianBlurFilter) {
     ImGui::SliderFloat2("Position offset", &offset[0], 0, 1000);
     static float scale = 1;
     ImGui::SliderFloat("Scale", &scale, 0, 1);
-    static float blur_radius = 20;
-    ImGui::SliderFloat("Blur radius", &blur_radius, 0, 200);
+    static float blur_amount[2] = {20, 20};
+    ImGui::SliderFloat2("Blur", &blur_amount[0], 0, 200);
     static bool clip_border = true;
     ImGui::Checkbox("Clip", &clip_border);
+    ImGui::End();
 
     auto blend = FilterContents::MakeBlend(Entity::BlendMode::kPlus,
                                            {boston, bridge, bridge});
 
     auto blur =
-        FilterContents::MakeGaussianBlur(blend, blur_radius, clip_border);
+        FilterContents::MakeGaussianBlur(blend, blur_amount[0], blur_amount[1]);
 
-    auto output_size = Size(blur->GetOutputSize());
-    Rect bounds(Point(offset[0], offset[1]) - output_size / 2 * scale,
-                output_size * scale);
-
-    ImGui::End();
+    // auto output_size = blur->GetBounds(entity).size;
+    // Rect bounds(Point(offset[0], offset[1]) - output_size / 2 * scale,
+    //             output_size * scale);
 
     Entity entity;
-    entity.SetPath(PathBuilder{}.AddRect(bounds).TakePath());
+    entity.SetPath(PathBuilder{}.AddRect(Rect(100, 100, 300, 300)).TakePath());
     entity.SetContents(blur);
     return entity.Render(context, pass);
   };

--- a/entity/shaders/texture_blend_screen.frag
+++ b/entity/shaders/texture_blend_screen.frag
@@ -6,11 +6,23 @@ uniform sampler2D texture_sampler_dst;
 uniform sampler2D texture_sampler_src;
 
 in vec2 v_texture_coords;
+in vec2 v_dst_uv_offset;
+in vec2 v_src_uv_offset;
 
 out vec4 frag_color;
 
+// Emulate SamplerAddressMode::ClampToBorder.
+vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
+  if (uv.x > 0 && uv.y > 0 && uv.x < 1 && uv.y < 1) {
+    return texture(tex, uv);
+  }
+  return vec4(0);
+}
+
 void main() {
-  vec4 dst = texture(texture_sampler_dst, v_texture_coords);
-  vec4 src = texture(texture_sampler_src, v_texture_coords);
+  vec4 dst =
+      SampleWithBorder(texture_sampler_dst, v_texture_coords + v_dst_uv_offset);
+  vec4 src =
+      SampleWithBorder(texture_sampler_src, v_texture_coords + v_src_uv_offset);
   frag_color = src + dst - src * dst;
 }

--- a/entity/shaders/texture_blend_screen.frag
+++ b/entity/shaders/texture_blend_screen.frag
@@ -5,9 +5,8 @@
 uniform sampler2D texture_sampler_dst;
 uniform sampler2D texture_sampler_src;
 
-in vec2 v_texture_coords;
-in vec2 v_dst_uv_offset;
-in vec2 v_src_uv_offset;
+in vec2 v_dst_texture_coords;
+in vec2 v_src_texture_coords;
 
 out vec4 frag_color;
 
@@ -20,9 +19,7 @@ vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
 }
 
 void main() {
-  vec4 dst =
-      SampleWithBorder(texture_sampler_dst, v_texture_coords + v_dst_uv_offset);
-  vec4 src =
-      SampleWithBorder(texture_sampler_src, v_texture_coords + v_src_uv_offset);
+  vec4 dst = SampleWithBorder(texture_sampler_dst, v_dst_texture_coords);
+  vec4 src = SampleWithBorder(texture_sampler_src, v_src_texture_coords);
   frag_color = src + dst - src * dst;
 }

--- a/entity/shaders/texture_blend_screen.vert
+++ b/entity/shaders/texture_blend_screen.vert
@@ -4,14 +4,20 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  vec2 dst_uv_offset;
+  vec2 src_uv_offset;
 } frame_info;
 
 in vec2 vertices;
 in vec2 texture_coords;
 
 out vec2 v_texture_coords;
+out vec2 v_dst_uv_offset;
+out vec2 v_src_uv_offset;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
   v_texture_coords = texture_coords;
+  v_dst_uv_offset = frame_info.dst_uv_offset;
+  v_src_uv_offset = frame_info.src_uv_offset;
 }

--- a/entity/shaders/texture_blend_screen.vert
+++ b/entity/shaders/texture_blend_screen.vert
@@ -4,20 +4,20 @@
 
 uniform FrameInfo {
   mat4 mvp;
-  vec2 dst_uv_offset;
-  vec2 src_uv_offset;
+  mat4 dst_uv_transform;
+  mat4 src_uv_transform;
 } frame_info;
 
 in vec2 vertices;
 in vec2 texture_coords;
 
-out vec2 v_texture_coords;
-out vec2 v_dst_uv_offset;
-out vec2 v_src_uv_offset;
+out vec2 v_dst_texture_coords;
+out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  v_texture_coords = texture_coords;
-  v_dst_uv_offset = frame_info.dst_uv_offset;
-  v_src_uv_offset = frame_info.src_uv_offset;
+  v_dst_texture_coords =
+      (frame_info.dst_uv_transform * vec4(texture_coords, 1.0, 1.0)).xy;
+  v_src_texture_coords =
+      (frame_info.src_uv_transform * vec4(texture_coords, 1.0, 1.0)).xy;
 }

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -142,6 +142,76 @@ TEST(GeometryTest, TestRecomposition2) {
   ASSERT_MATRIX_NEAR(matrix, Matrix{result.value()});
 }
 
+TEST(GeometryTest, MatrixVectorMultiplication) {
+  {
+    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+                  Matrix::MakeRotationZ(Radians{M_PI_2}) *
+                  Matrix::MakeScale({2.0, 2.0, 2.0});
+    auto vector = Vector4(10, 20, 30, 2);
+
+    Vector4 result = matrix * vector;
+    auto expected = Vector4(160, 220, 260, 2);
+    ASSERT_VECTOR4_NEAR(result, expected);
+  }
+
+  {
+    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+                  Matrix::MakeRotationZ(Radians{M_PI_2}) *
+                  Matrix::MakeScale({2.0, 2.0, 2.0});
+    auto vector = Vector3(10, 20, 30);
+
+    Vector3 result = matrix * vector;
+    auto expected = Vector3(60, 120, 160);
+    ASSERT_VECTOR3_NEAR(result, expected);
+  }
+
+  {
+    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+                  Matrix::MakeRotationZ(Radians{M_PI_2}) *
+                  Matrix::MakeScale({2.0, 2.0, 2.0});
+    auto vector = Point(10, 20);
+
+    Point result = matrix * vector;
+    auto expected = Point(60, 120);
+    ASSERT_POINT_NEAR(result, expected);
+  }
+}
+
+TEST(GeometryTest, MatrixTransformDirection) {
+  {
+    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+                  Matrix::MakeRotationZ(Radians{M_PI_2}) *
+                  Matrix::MakeScale({2.0, 2.0, 2.0});
+    auto vector = Vector4(10, 20, 30, 2);
+
+    Vector4 result = matrix.TransformDirection(vector);
+    auto expected = Vector4(-40, 20, 60, 2);
+    ASSERT_VECTOR4_NEAR(result, expected);
+  }
+
+  {
+    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+                  Matrix::MakeRotationZ(Radians{M_PI_2}) *
+                  Matrix::MakeScale({2.0, 2.0, 2.0});
+    auto vector = Vector3(10, 20, 30);
+
+    Vector3 result = matrix.TransformDirection(vector);
+    auto expected = Vector3(-40, 20, 60);
+    ASSERT_VECTOR3_NEAR(result, expected);
+  }
+
+  {
+    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+                  Matrix::MakeRotationZ(Radians{M_PI_2}) *
+                  Matrix::MakeScale({2.0, 2.0, 2.0});
+    auto vector = Point(10, 20);
+
+    Point result = matrix.TransformDirection(vector);
+    auto expected = Point(-40, 20);
+    ASSERT_POINT_NEAR(result, expected);
+  }
+}
+
 TEST(GeometryTest, QuaternionLerp) {
   auto q1 = Quaternion{{0.0, 0.0, 1.0}, 0.0};
   auto q2 = Quaternion{{0.0, 0.0, 1.0}, M_PI_4};
@@ -567,6 +637,13 @@ TEST(GeometryTest, PointReflect) {
   }
 }
 
+TEST(GeometryTest, PointAbs) {
+  Point a(-1, -2);
+  auto a_abs = a.Abs();
+  auto expected = Point(1, 2);
+  ASSERT_POINT_NEAR(a_abs, expected);
+}
+
 TEST(GeometryTest, ColorPremultiply) {
   {
     Color a(1.0, 0.5, 0.2, 0.5);
@@ -720,6 +797,21 @@ TEST(GeometryTest, RectContainsRect) {
     Rect b(0, 0, 300, 300);
     ASSERT_FALSE(a.Contains(b));
   }
+}
+
+TEST(GeometryTest, RectGetPoints) {
+  Rect r(100, 200, 300, 400);
+  auto points = r.GetPoints();
+  ASSERT_POINT_NEAR(points[0], Point(100, 200));
+  ASSERT_POINT_NEAR(points[1], Point(400, 200));
+  ASSERT_POINT_NEAR(points[2], Point(100, 600));
+  ASSERT_POINT_NEAR(points[3], Point(400, 600));
+}
+
+TEST(GeometryTest, RectMakePointBounds) {
+  auto r = Rect::MakePointBounds({Point(1, 5), Point(4, -1), Point(0, 6)});
+  auto expected = Rect(0, -1, 4, 7);
+  ASSERT_RECT_NEAR(r, expected);
 }
 
 TEST(GeometryTest, CubicPathComponentPolylineDoesNotIncludePointOne) {

--- a/geometry/geometry_unittests.h
+++ b/geometry/geometry_unittests.h
@@ -75,6 +75,24 @@ inline ::testing::AssertionResult PointNear(impeller::Point a,
                : ::testing::AssertionFailure() << "Points are not equal.";
 }
 
+inline ::testing::AssertionResult Vector3Near(impeller::Vector3 a,
+                                              impeller::Vector3 b) {
+  auto equal =
+      NumberNear(a.x, b.x) && NumberNear(a.y, b.y) && NumberNear(a.z, b.z);
+
+  return equal ? ::testing::AssertionSuccess()
+               : ::testing::AssertionFailure() << "Vector3s are not equal.";
+}
+
+inline ::testing::AssertionResult Vector4Near(impeller::Vector4 a,
+                                              impeller::Vector4 b) {
+  auto equal = NumberNear(a.x, b.x) && NumberNear(a.y, b.y) &&
+               NumberNear(a.z, b.z) && NumberNear(a.w, b.w);
+
+  return equal ? ::testing::AssertionSuccess()
+               : ::testing::AssertionFailure() << "Vector4s are not equal.";
+}
+
 inline ::testing::AssertionResult SizeNear(impeller::Size a, impeller::Size b) {
   auto equal = NumberNear(a.width, b.width) && NumberNear(a.height, b.height);
 
@@ -87,4 +105,6 @@ inline ::testing::AssertionResult SizeNear(impeller::Size a, impeller::Size b) {
 #define ASSERT_RECT_NEAR(a, b) ASSERT_PRED2(&::RectNear, a, b)
 #define ASSERT_COLOR_NEAR(a, b) ASSERT_PRED2(&::ColorNear, a, b)
 #define ASSERT_POINT_NEAR(a, b) ASSERT_PRED2(&::PointNear, a, b)
+#define ASSERT_VECTOR3_NEAR(a, b) ASSERT_PRED2(&::Vector3Near, a, b)
+#define ASSERT_VECTOR4_NEAR(a, b) ASSERT_PRED2(&::Vector4Near, a, b)
 #define ASSERT_SIZE_NEAR(a, b) ASSERT_PRED2(&::SizeNear, a, b)

--- a/geometry/matrix.cc
+++ b/geometry/matrix.cc
@@ -249,7 +249,7 @@ std::optional<MatrixDecomposition> Matrix::Decompose() const {
      *  prhs by the inverse.
      */
 
-    result.perspective = rightHandSide * perpectiveMatrix.Invert().Transpose();
+    result.perspective = perpectiveMatrix.Invert().Transpose() * rightHandSide;
 
     /*
      *  Clear the perspective partition.

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -12,7 +12,6 @@
 #include "impeller/geometry/matrix_decomposition.h"
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/quaternion.h"
-#include "impeller/geometry/rect.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/shear.h"
 #include "impeller/geometry/size.h"

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -284,8 +284,7 @@ struct Matrix {
   constexpr Vector4 TransformDirection(const Vector4& v) const {
     return Vector4(v.x * m[0] + v.y * m[4] + v.z * m[8],
                    v.x * m[1] + v.y * m[5] + v.z * m[9],
-                   v.x * m[2] + v.y * m[6] + v.z * m[10],
-                   v.x * m[3] + v.y * m[7] + v.z * m[11]);
+                   v.x * m[2] + v.y * m[6] + v.z * m[10], v.w);
   }
 
   constexpr Vector3 TransformDirection(const Vector3& v) const {
@@ -295,8 +294,7 @@ struct Matrix {
   }
 
   constexpr Vector2 TransformDirection(const Vector2& v) const {
-    return Vector2(v.x * m[0] + v.y * m[4],
-                   v.x * m[1] + v.y * m[5]);
+    return Vector2(v.x * m[0] + v.y * m[4], v.x * m[1] + v.y * m[5]);
   }
 
   template <class T>

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -12,6 +12,7 @@
 #include "impeller/geometry/matrix_decomposition.h"
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/quaternion.h"
+#include "impeller/geometry/rect.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/shear.h"
 #include "impeller/geometry/size.h"
@@ -259,11 +260,27 @@ struct Matrix {
 
   Matrix operator-(const Vector3& t) const { return Translate(-t); }
 
-  Matrix operator*(const Vector3& s) const { return Scale(s); }
-
   Matrix operator*(const Matrix& m) const { return Multiply(m); }
 
   Matrix operator+(const Matrix& m) const;
+
+  constexpr Vector4 operator*(const Vector4& v) const {
+    return Vector4(v.x * m[0] + v.y * m[4] + v.z * m[8] + v.w * m[12],
+                   v.x * m[1] + v.y * m[5] + v.z * m[9] + v.w * m[13],
+                   v.x * m[2] + v.y * m[6] + v.z * m[10] + v.w * m[14],
+                   v.x * m[3] + v.y * m[7] + v.z * m[11] + v.w * m[15]);
+  }
+
+  constexpr Vector3 operator*(const Vector3& v) const {
+    return Vector3(v.x * m[0] + v.y * m[4] + v.z * m[8] + m[12],
+                   v.x * m[1] + v.y * m[5] + v.z * m[9] + m[13],
+                   v.x * m[2] + v.y * m[6] + v.z * m[10] + m[14]);
+  }
+
+  constexpr Point operator*(const Point& v) const {
+    return Point(v.x * m[0] + v.y * m[4] + m[12],
+                 v.x * m[1] + v.y * m[5] + m[13]);
+  }
 
   template <class T>
   static constexpr Matrix MakeOrthographic(TSize<T> size) {
@@ -279,17 +296,9 @@ struct Matrix {
 static_assert(sizeof(struct Matrix) == sizeof(Scalar) * 16,
               "The matrix must be of consistent size.");
 
-inline Vector4 operator*(const Vector4& v, const Matrix& m) {
-  return Vector4(v.x * m.m[0] + v.y * m.m[4] + v.z * m.m[8] + v.w * m.m[12],
-                 v.x * m.m[1] + v.y * m.m[5] + v.z * m.m[9] + v.w * m.m[13],
-                 v.x * m.m[2] + v.y * m.m[6] + v.z * m.m[10] + v.w * m.m[14],
-                 v.x * m.m[3] + v.y * m.m[7] + v.z * m.m[11] + v.w * m.m[15]);
-}
-
 }  // namespace impeller
 
 namespace std {
-
 inline std::ostream& operator<<(std::ostream& out, const impeller::Matrix& m) {
   out << "(";
   for (size_t i = 0; i < 4u; i++) {

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -282,6 +282,24 @@ struct Matrix {
                  v.x * m[1] + v.y * m[5] + m[13]);
   }
 
+  constexpr Vector4 TransformDirection(const Vector4& v) const {
+    return Vector4(v.x * m[0] + v.y * m[4] + v.z * m[8],
+                   v.x * m[1] + v.y * m[5] + v.z * m[9],
+                   v.x * m[2] + v.y * m[6] + v.z * m[10],
+                   v.x * m[3] + v.y * m[7] + v.z * m[11]);
+  }
+
+  constexpr Vector3 TransformDirection(const Vector3& v) const {
+    return Vector3(v.x * m[0] + v.y * m[4] + v.z * m[8],
+                   v.x * m[1] + v.y * m[5] + v.z * m[9],
+                   v.x * m[2] + v.y * m[6] + v.z * m[10]);
+  }
+
+  constexpr Vector2 TransformDirection(const Vector2& v) const {
+    return Vector2(v.x * m[0] + v.y * m[4],
+                   v.x * m[1] + v.y * m[5]);
+  }
+
   template <class T>
   static constexpr Matrix MakeOrthographic(TSize<T> size) {
     // Per assumptions about NDC documented above.

--- a/geometry/point.h
+++ b/geometry/point.h
@@ -180,6 +180,8 @@ struct TPoint {
     return {x / length, y / length};
   }
 
+  constexpr TPoint Abs() const { return {std::fabs(x), std::fabs(y)}; }
+
   constexpr Type Cross(const TPoint& p) const { return (x * p.y) - (y * p.x); }
 
   constexpr Type Dot(const TPoint& p) const { return (x * p.x) + (y * p.y); }

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -51,16 +51,19 @@ struct TRect {
     return TRect(0.0, 0.0, size.width, size.height);
   }
 
-  constexpr static TRect MakePointBounds(const std::array<TPoint<Type>, 4>& p) {
-    auto left = p[0].x;
-    auto top = p[0].y;
-    auto right = p[0].x;
-    auto bottom = p[0].y;
-    for (uint i = 1; i < 4; i++) {
-      left = std::min(left, p[i].x);
-      top = std::min(top, p[i].y);
-      right = std::max(right, p[i].x);
-      bottom = std::max(bottom, p[i].y);
+  constexpr static TRect MakePointBounds(
+      const std::vector<TPoint<Type>>& points) {
+    auto left = points[0].x;
+    auto top = points[0].y;
+    auto right = points[0].x;
+    auto bottom = points[0].y;
+    if (points.size() > 1) {
+      for (uint i = 1; i < points.size(); i++) {
+        left = std::min(left, points[i].x);
+        top = std::min(top, points[i].y);
+        right = std::max(right, points[i].x);
+        bottom = std::max(bottom, points[i].y);
+      }
     }
     return TRect::MakeLTRB(left, top, right, bottom);
   }

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <optional>
 #include <ostream>
 #include <vector>
@@ -48,6 +49,20 @@ struct TRect {
 
   constexpr static TRect MakeSize(const TSize<Type>& size) {
     return TRect(0.0, 0.0, size.width, size.height);
+  }
+
+  constexpr static TRect MakePointBounds(const std::array<TPoint<Type>, 4>& p) {
+    auto left = p[0].x;
+    auto top = p[0].x;
+    auto right = p[0].y;
+    auto bottom = p[0].y;
+    for (uint i = 1; i < 4; i++) {
+      left = std::min(left, p[i].x);
+      top = std::min(top, p[i].y);
+      right = std::max(right, p[i].x);
+      bottom = std::max(bottom, p[i].y);
+    }
+    return TRect::MakeLTRB(left, top, right, bottom);
   }
 
   template <class U>
@@ -114,6 +129,15 @@ struct TRect {
     const auto right = std::max(origin.x, origin.x + size.width);
     const auto bottom = std::max(origin.y, origin.y + size.height);
     return {left, top, right, bottom};
+  }
+
+  constexpr std::array<TPoint<T>, 4> GetPoints() const {
+    const auto left = std::min(origin.x, origin.x + size.width);
+    const auto top = std::min(origin.y, origin.y + size.height);
+    const auto right = std::max(origin.x, origin.x + size.width);
+    const auto bottom = std::max(origin.y, origin.y + size.height);
+    return {TPoint(left, top), TPoint(right, top), TPoint(left, bottom),
+            TPoint(right, bottom)};
   }
 
   constexpr TRect Union(const TRect& o) const {

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -53,8 +53,8 @@ struct TRect {
 
   constexpr static TRect MakePointBounds(const std::array<TPoint<Type>, 4>& p) {
     auto left = p[0].x;
-    auto top = p[0].x;
-    auto right = p[0].y;
+    auto top = p[0].y;
+    auto right = p[0].x;
     auto bottom = p[0].y;
     for (uint i = 1; i < 4; i++) {
       left = std::min(left, p[i].x);

--- a/geometry/scalar.h
+++ b/geometry/scalar.h
@@ -14,6 +14,8 @@ namespace impeller {
 
 using Scalar = float;
 
+constexpr Scalar kEhCloseEnough = 1e-3f;
+
 template <class T, class = std::enable_if_t<std::is_arithmetic_v<T>>>
 constexpr T Absolute(const T& val) {
   return val >= T{} ? val : -val;
@@ -21,7 +23,7 @@ constexpr T Absolute(const T& val) {
 
 constexpr inline bool ScalarNearlyEqual(Scalar x,
                                         Scalar y,
-                                        Scalar tolerance = 1e-3) {
+                                        Scalar tolerance = kEhCloseEnough) {
   return Absolute(x - y) <= tolerance;
 }
 

--- a/geometry/size.h
+++ b/geometry/size.h
@@ -47,6 +47,10 @@ struct TSize {
             static_cast<Scalar>(height) / scale};
   }
 
+  constexpr TSize operator/(const TSize& s) const {
+    return {width / s.width, height / s.height};
+  }
+
   constexpr bool operator==(const TSize& s) const {
     return s.width == width && s.height == height;
   }


### PR DESCRIPTION
This changes a lot about how the filters work and lines us up to make the paint image filter/advanced blends work. A lot of the changes here were made on the fly in order to avoid landing intermediary changes that reduce functionality.

Changes:
* All Contents can now compute their own screen space bounds given an entity/transform.
* FilterContents computes its bounds as the union of its inputs' bounds.
* As a consequence, `FilterContents` has enough information at render any contents to a texture at the correct end resolution, and so I extended filter inputs to allow for _any_ Contents type in addition to filters and textures. This will make supporting the paint filter very easy.
* The gaussian blur filter has a similar interface to Skia's blur now. And now that filters use correct texture sizes, the blur directions are transformed using current transform's basis to match Skia's behavior.

Optimization ideas for later:
* Texture inputs are currently transformed and rendered to the correctly sized texture -- we can refactor this pass away by  having FilterContents compute either a local transform or mapped UVs per input and give this info to the filter implementations to use for drawing.
* There are a bunch of constructors we can add to Matrix to make this overall less pessimized.
* Cache bounds rects.

https://user-images.githubusercontent.com/919017/159614739-9a93a6fb-385c-4ab0-a79a-d2b937afcf78.mov

Usage:
```cpp
    auto bridge = CreateTextureForFixture("bay_bridge.jpg");
    auto boston = CreateTextureForFixture("boston.jpg");

    auto blend = FilterContents::MakeBlend(Entity::BlendMode::kPlus, {boston, bridge, bridge});
    auto blur = FilterContents::MakeGaussianBlur(blend, 20, 20);

    Entity entity;
    entity.SetPath(PathBuilder{}.AddRect({100, 100, 300, 300}).TakePath());
    entity.SetContents(blur);
    entity.SetTransformation(my_fancy_transform);

    entity.Render(content_context, render_pass);
```