### PR TITLE
Add difference clipping

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -123,6 +123,22 @@ TEST_F(AiksTest, CanRenderNestedClips) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_F(AiksTest, CanRenderDifferenceClips) {
+  Canvas canvas;
+  canvas.ClipPath(PathBuilder{}.AddCircle({400, 400}, 200).TakePath());
+  canvas.ClipPath(PathBuilder{}.AddCircle({300, 300}, 20).TakePath(),
+                  Entity::ClipOperation::kDifference);
+  canvas.ClipPath(PathBuilder{}.AddCircle({500, 300}, 20).TakePath(),
+                  Entity::ClipOperation::kDifference);
+
+  // Draw a big fuchsia rectangle covering everything.
+  Paint paint;
+  paint.color = Color::Fuchsia();
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 1000, 1000), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_F(AiksTest, ClipsUseCurrentTransform) {
   std::array<Color, 5> colors = {Color::White(), Color::Black(),
                                  Color::SkyBlue(), Color::Red(),

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -151,11 +151,14 @@ void Canvas::SaveLayer(Paint paint, std::optional<Rect> bounds) {
   }
 }
 
-void Canvas::ClipPath(Path path) {
+void Canvas::ClipPath(Path path, Entity::ClipOperation clip_op) {
+  auto contents = std::make_shared<ClipContents>();
+  contents->SetClipOperation(clip_op);
+
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetPath(std::move(path));
-  entity.SetContents(std::make_shared<ClipContents>());
+  entity.SetContents(std::move(contents));
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetAddsToCoverage(false);
 

--- a/aiks/canvas.h
+++ b/aiks/canvas.h
@@ -72,7 +72,9 @@ class Canvas {
                      Rect dest,
                      Paint paint);
 
-  void ClipPath(Path path);
+  void ClipPath(
+      Path path,
+      Entity::ClipOperation clip_op = Entity::ClipOperation::kIntersect);
 
   void DrawShadow(Path path, Color color, Scalar elevation);
 

--- a/display_list/display_list_dispatcher.cc
+++ b/display_list/display_list_dispatcher.cc
@@ -159,7 +159,7 @@ void DisplayListDispatcher::setInvertColors(bool invert) {
   UNIMPLEMENTED;
 }
 
-std::optional<Entity::BlendMode> ToBlendMode(flutter::DlBlendMode mode) {
+static std::optional<Entity::BlendMode> ToBlendMode(flutter::DlBlendMode mode) {
   switch (mode) {
     case flutter::DlBlendMode::kClear:
       return Entity::BlendMode::kClear;
@@ -351,12 +351,21 @@ static Rect ToRect(const SkRect& rect) {
   return Rect::MakeLTRB(rect.fLeft, rect.fTop, rect.fRight, rect.fBottom);
 }
 
+static Entity::ClipOperation ToClipOperation(SkClipOp clip_op) {
+  switch (clip_op) {
+    case SkClipOp::kDifference:
+      return Entity::ClipOperation::kDifference;
+    case SkClipOp::kIntersect:
+      return Entity::ClipOperation::kIntersect;
+  }
+}
+
 // |flutter::Dispatcher|
 void DisplayListDispatcher::clipRect(const SkRect& rect,
                                      SkClipOp clip_op,
                                      bool is_aa) {
   auto path = PathBuilder{}.AddRect(ToRect(rect)).TakePath();
-  canvas_.ClipPath(std::move(path));
+  canvas_.ClipPath(std::move(path), ToClipOperation(clip_op));
 }
 
 static PathBuilder::RoundingRadii ToRoundingRadii(const SkRRect& rrect) {
@@ -444,7 +453,7 @@ static Path ToPath(const SkRRect& rrect) {
 void DisplayListDispatcher::clipRRect(const SkRRect& rrect,
                                       SkClipOp clip_op,
                                       bool is_aa) {
-  canvas_.ClipPath(ToPath(rrect));
+  canvas_.ClipPath(ToPath(rrect), ToClipOperation(clip_op));
 }
 
 // |flutter::Dispatcher|

--- a/entity/contents/clip_contents.h
+++ b/entity/contents/clip_contents.h
@@ -10,11 +10,9 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/contents.h"
-#include "impeller/typographer/glyph_atlas.h"
+#include "impeller/entity/entity.h"
 
 namespace impeller {
-
-class GlyphAtlas;
 
 class ClipContents final : public Contents {
  public:
@@ -22,12 +20,16 @@ class ClipContents final : public Contents {
 
   ~ClipContents();
 
+  void SetClipOperation(Entity::ClipOperation clip_op);
+
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;
 
  private:
+  Entity::ClipOperation clip_op_ = Entity::ClipOperation::kIntersect;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ClipContents);
 };
 
@@ -36,8 +38,6 @@ class ClipRestoreContents final : public Contents {
   ClipRestoreContents();
 
   ~ClipRestoreContents();
-
-  void SetGlyphAtlas(std::shared_ptr<GlyphAtlas> atlas);
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/entity/contents/content_context.cc
+++ b/entity/contents/content_context.cc
@@ -33,41 +33,20 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
   // TODO(98684): Rework this API to allow fetching the descriptor without
   //              waiting for the pipeline to build.
   if (auto solid_fill_pipeline = solid_fill_pipelines_[{}]->WaitAndGet()) {
-    // Clip pipeline.
-    {
-      auto clip_pipeline_descriptor = solid_fill_pipeline->GetDescriptor();
-      clip_pipeline_descriptor.SetLabel("Clip Pipeline");
-      // Write to the stencil buffer.
-      StencilAttachmentDescriptor stencil0;
-      stencil0.stencil_compare = CompareFunction::kEqual;
-      stencil0.depth_stencil_pass = StencilOperation::kIncrementClamp;
-      clip_pipeline_descriptor.SetStencilAttachmentDescriptors(stencil0);
-      // Disable write to all color attachments.
-      auto color_attachments =
-          clip_pipeline_descriptor.GetColorAttachmentDescriptors();
-      for (auto& color_attachment : color_attachments) {
-        color_attachment.second.write_mask =
-            static_cast<uint64_t>(ColorWriteMask::kNone);
-      }
-      clip_pipeline_descriptor.SetColorAttachmentDescriptors(
-          std::move(color_attachments));
-      clip_pipelines_[{}] =
-          std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
+    auto clip_pipeline_descriptor = solid_fill_pipeline->GetDescriptor();
+    clip_pipeline_descriptor.SetLabel("Clip Pipeline");
+    // Disable write to all color attachments.
+    auto color_attachments =
+        clip_pipeline_descriptor.GetColorAttachmentDescriptors();
+    for (auto& color_attachment : color_attachments) {
+      color_attachment.second.write_mask =
+          static_cast<uint64_t>(ColorWriteMask::kNone);
     }
+    clip_pipeline_descriptor.SetColorAttachmentDescriptors(
+        std::move(color_attachments));
+    clip_pipelines_[{}] =
+        std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
 
-    // Clip restoration pipeline.
-    {
-      auto clip_pipeline_descriptor =
-          clip_pipelines_[{}]->WaitAndGet()->GetDescriptor();
-      clip_pipeline_descriptor.SetLabel("Clip Restoration Pipeline");
-      // Write to the stencil buffer.
-      StencilAttachmentDescriptor stencil0;
-      stencil0.stencil_compare = CompareFunction::kLess;
-      stencil0.depth_stencil_pass = StencilOperation::kSetToReferenceValue;
-      clip_pipeline_descriptor.SetStencilAttachmentDescriptors(stencil0);
-      clip_restoration_pipelines_[{}] = std::make_unique<ClipPipeline>(
-          *context_, std::move(clip_pipeline_descriptor));
-    }
   } else {
     return;
   }

--- a/entity/contents/content_context.h
+++ b/entity/contents/content_context.h
@@ -48,7 +48,7 @@ using SolidStrokePipeline =
     PipelineT<SolidStrokeVertexShader, SolidStrokeFragmentShader>;
 using GlyphAtlasPipeline =
     PipelineT<GlyphAtlasVertexShader, GlyphAtlasFragmentShader>;
-// Instead of requiring new shaders for clips,  the solid fill stages are used
+// Instead of requiring new shaders for clips, the solid fill stages are used
 // to redirect writing to the stencil instead of color attachments.
 using ClipPipeline = PipelineT<SolidFillVertexShader, SolidFillFragmentShader>;
 
@@ -123,11 +123,6 @@ class ContentContext {
     return GetPipeline(clip_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline> GetClipRestorePipeline(
-      ContentContextOptions opts) const {
-    return GetPipeline(clip_restoration_pipelines_, opts);
-  }
-
   std::shared_ptr<Pipeline> GetGlyphAtlasPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(glyph_atlas_pipelines_, opts);
@@ -155,7 +150,6 @@ class ContentContext {
   mutable Variants<GaussianBlurPipeline> gaussian_blur_pipelines_;
   mutable Variants<SolidStrokePipeline> solid_stroke_pipelines_;
   mutable Variants<ClipPipeline> clip_pipelines_;
-  mutable Variants<ClipPipeline> clip_restoration_pipelines_;
   mutable Variants<GlyphAtlasPipeline> glyph_atlas_pipelines_;
 
   static void ApplyOptionsToDescriptor(PipelineDescriptor& desc,

--- a/entity/entity.h
+++ b/entity/entity.h
@@ -48,6 +48,11 @@ class Entity {
     kLastAdvancedBlendMode = kScreen,
   };
 
+  enum class ClipOperation {
+    kDifference,
+    kIntersect,
+  };
+
   Entity();
 
   ~Entity();


### PR DESCRIPTION
This works with two commands:
1. Increment the stencil area matching the current depth.
2. Decrement the stencil area matching the incremented depth and the given clip path.

My initial implementation was to just prepend a rectangle to the clip path (multiplied against the inverse transform so it ends up in the correct location to cover the entire render target) and let the tessellator do the inversion, but I didn't like how complex the geometry was that the tessellator was outputting and I didn't want to risk not covering corner cases, so I opted for this safer option instead.

Screenshot from the test, which uses difference clips to punch out the eyes/mouth, then restores the clip and draws a shape that partly covers the eyes:
![Screen Shot 2022-03-27 at 7 16 06 PM](https://user-images.githubusercontent.com/919017/160316122-eecdbdaf-734a-4e66-9f7c-590d31d8468d.png)
