### PR TITLE
Premultiply gradient colors

### DIFF
--- a/entity/contents/linear_gradient_contents.cc
+++ b/entity/contents/linear_gradient_contents.cc
@@ -61,8 +61,8 @@ bool LinearGradientContents::Render(const ContentContext& renderer,
   FS::GradientInfo gradient_info;
   gradient_info.start_point = start_point_;
   gradient_info.end_point = end_point_;
-  gradient_info.start_color = colors_[0];
-  gradient_info.end_color = colors_[1];
+  gradient_info.start_color = colors_[0].Premultiply();
+  gradient_info.end_color = colors_[1].Premultiply();
 
   Command cmd;
   cmd.label = "LinearGradientFill";


### PR DESCRIPTION
I noticed the tree shadows looked kind of inverted in the page flip example and checked out the linear gradient to see if we were managing colors right -- looks like I missed this one when switching everything to premultiplied source colors. 

Before:
![Screen Shot 2022-03-28 at 3 45 29 AM](https://user-images.githubusercontent.com/919017/160383581-d2932cdb-32e7-4d9c-9263-1a21d4229885.png)


After:
![Screen Shot 2022-03-28 at 3 51 24 AM](https://user-images.githubusercontent.com/919017/160383622-1b55e299-b6ba-40e5-9a74-8bc2947ca751.png)

