### PR TITLE
Fix SaveLayer/entity subpass behavioral problems

### DIFF
--- a/aiks/aiks_playground.cc
+++ b/aiks/aiks_playground.cc
@@ -13,6 +13,13 @@ AiksPlayground::AiksPlayground() = default;
 AiksPlayground::~AiksPlayground() = default;
 
 bool AiksPlayground::OpenPlaygroundHere(const Picture& picture) {
+  return OpenPlaygroundHere(
+      [&picture](AiksContext& renderer, RenderPass& pass) -> bool {
+        return renderer.Render(picture, pass);
+      });
+}
+
+bool AiksPlayground::OpenPlaygroundHere(AiksPlaygroundCallback callback) {
   if (!Playground::is_enabled()) {
     return true;
   }
@@ -24,8 +31,8 @@ bool AiksPlayground::OpenPlaygroundHere(const Picture& picture) {
   }
 
   return Playground::OpenPlaygroundHere(
-      [&renderer, &picture](RenderPass& pass) -> bool {
-        return renderer.Render(picture, pass);
+      [&renderer, &callback](RenderPass& pass) -> bool {
+        return callback(renderer, pass);
       });
 }
 

--- a/aiks/aiks_playground.h
+++ b/aiks/aiks_playground.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "flutter/fml/macros.h"
+#include "impeller/aiks/aiks_context.h"
 #include "impeller/aiks/picture.h"
 #include "impeller/playground/playground.h"
 
@@ -12,11 +13,15 @@ namespace impeller {
 
 class AiksPlayground : public Playground {
  public:
+  using AiksPlaygroundCallback = std::function<bool(AiksContext& renderer, RenderPass& pass)>;
+
   AiksPlayground();
 
   ~AiksPlayground();
 
   bool OpenPlaygroundHere(const Picture& picture);
+
+  bool OpenPlaygroundHere(AiksPlaygroundCallback callback);
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(AiksPlayground);

--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -533,7 +533,6 @@ TEST_F(AiksTest, CoverageOriginShouldBeAccountedForInSubpasses) {
                                              Color::White(), Color::White());
     auto bounds = Rect::MakeLTRB(b0.x, b0.y, b1.x, b1.y);
 
-    canvas.Translate(Point(30, 30));
     canvas.DrawRect(bounds, Paint{.color = Color::Yellow(),
                                   .stroke_width = 5.0f,
                                   .style = Paint::Style::kStroke});

--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -516,6 +516,25 @@ TEST_F(AiksTest, PathsShouldHaveUniformAlpha) {
     }
     canvas.Translate({-240, 60});
   }
+}
+
+TEST_F(AiksTest, CoverageOriginShouldBeAccountedForInSubpasses) {
+  Canvas canvas;
+
+  Paint alpha;
+  alpha.color = Color::Red().WithAlpha(0.5);
+
+  auto current = Point{25, 25};
+  const auto offset = Point{25, 25};
+  const auto size = Size(100, 100);
+
+  canvas.SaveLayer(alpha);
+
+  canvas.DrawRect({current, size}, Paint{.color = Color::Red()});
+  canvas.DrawRect({current += offset, size}, Paint{.color = Color::Green()});
+  canvas.DrawRect({current += offset, size}, Paint{.color = Color::Blue()});
+
+  canvas.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -264,14 +264,13 @@ size_t Canvas::GetStencilDepth() const {
 
 void Canvas::Save(bool create_subpass) {
   auto entry = CanvasStackEntry{};
+  entry.xformation = xformation_stack_.back().xformation;
+  entry.stencil_depth = xformation_stack_.back().stencil_depth;
   if (create_subpass) {
     entry.is_subpass = true;
     current_pass_ = GetCurrentPass().AddSubpass(std::make_unique<EntityPass>());
     current_pass_->SetTransformation(xformation_stack_.back().xformation);
     current_pass_->SetStencilDepth(xformation_stack_.back().stencil_depth);
-  } else {
-    entry.xformation = xformation_stack_.back().xformation;
-    entry.stencil_depth = xformation_stack_.back().stencil_depth;
   }
   xformation_stack_.emplace_back(std::move(entry));
 }

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -31,7 +31,12 @@ Contents::~Contents() = default;
 
 Rect Contents::GetBounds(const Entity& entity) const {
   const auto& transform = entity.GetTransformation();
-  auto points = entity.GetPath().GetBoundingBox()->GetPoints();
+  auto bounds = entity.GetPath().GetBoundingBox();
+  if (!bounds.has_value()) {
+    return Rect();
+  }
+
+  auto points = bounds->GetPoints();
   for (uint i = 0; i < points.size(); i++) {
     points[i] = transform * points[i];
   }

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -35,12 +35,7 @@ Rect Contents::GetBounds(const Entity& entity) const {
   if (!bounds.has_value()) {
     return Rect();
   }
-
-  auto points = bounds->GetPoints();
-  for (uint i = 0; i < points.size(); i++) {
-    points[i] = transform * points[i];
-  }
-  return Rect::MakePointBounds({points.begin(), points.end()});
+  return bounds->TransformBounds(transform);
 }
 
 std::optional<Snapshot> Contents::RenderToTexture(

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -30,12 +30,7 @@ Contents::Contents() = default;
 Contents::~Contents() = default;
 
 Rect Contents::GetBounds(const Entity& entity) const {
-  const auto& transform = entity.GetTransformation();
-  auto bounds = entity.GetPath().GetBoundingBox();
-  if (!bounds.has_value()) {
-    return Rect();
-  }
-  return bounds->TransformBounds(transform);
+  return entity.GetTransformedPathBounds();
 }
 
 std::optional<Snapshot> Contents::RenderToTexture(

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -31,7 +31,11 @@ void Entity::SetPath(Path path) {
 }
 
 Rect Entity::GetTransformedPathBounds() const {
-  return GetPath().GetBoundingBox()->TransformBounds(GetTransformation());
+  auto bounds = GetPath().GetBoundingBox();
+  if (!bounds.has_value()) {
+    return Rect();
+  }
+  return bounds->TransformBounds(GetTransformation());
 }
 
 void Entity::SetAddsToCoverage(bool adds) {

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -31,13 +31,7 @@ void Entity::SetPath(Path path) {
 }
 
 Rect Entity::GetTransformedPathBounds() const {
-  auto points = GetPath().GetBoundingBox()->GetPoints();
-
-  const auto& transform = GetTransformation();
-  for (uint i = 0; i < points.size(); i++) {
-    points[i] = transform * points[i];
-  }
-  return Rect::MakePointBounds({points.begin(), points.end()});
+  return GetPath().GetBoundingBox()->TransformBounds(GetTransformation());
 }
 
 void Entity::SetAddsToCoverage(bool adds) {

--- a/entity/entity_pass.cc
+++ b/entity/entity_pass.cc
@@ -215,17 +215,6 @@ bool EntityPass::Render(ContentContext& renderer, RenderPass& parent_pass) {
       return false;
     }
 
-    FML_LOG(ERROR) << "Subpass coverage: " << subpass_coverage->GetLeft() << " "
-                   << subpass_coverage->GetTop() << " "
-                   << subpass_coverage->GetRight() << " "
-                   << subpass_coverage->GetBottom();
-    FML_LOG(ERROR) << "Subpass texture position: "
-                   << subpass->texture_position_.x << " "
-                   << subpass->texture_position_.y;
-    FML_LOG(ERROR) << "Subpass texture size: "
-                   << subpass_target.GetRenderTargetSize().width << " "
-                   << subpass_target.GetRenderTargetSize().height;
-
     Entity entity;
     entity.SetPath(PathBuilder{}
                        .AddRect(Rect::MakeSize(subpass_coverage->size))

--- a/entity/entity_pass.cc
+++ b/entity/entity_pass.cc
@@ -112,22 +112,16 @@ bool EntityPass::Render(ContentContext& renderer,
                         Point position) const {
   TRACE_EVENT0("impeller", "EntityPass::Render");
 
-  if (position.IsZero()) {
-    for (const auto& entity : entities_) {
-      if (!entity.Render(renderer, parent_pass)) {
-        return false;
-      }
-    }
-  } else {
-    // If the pass image is going to be rendered with a non-zero position, apply
-    // the negative translation to entity copies before rendering them so that
-    // they'll end up rendering to the correct on-screen position.
-    for (Entity entity : entities_) {
+  for (Entity entity : entities_) {
+    if (!position.IsZero()) {
+      // If the pass image is going to be rendered with a non-zero position,
+      // apply the negative translation to entity copies before rendering them
+      // so that they'll end up rendering to the correct on-screen position.
       entity.SetTransformation(Matrix::MakeTranslation(Vector3(-position)) *
                                entity.GetTransformation());
-      if (!entity.Render(renderer, parent_pass)) {
-        return false;
-      }
+    }
+    if (!entity.Render(renderer, parent_pass)) {
+      return false;
     }
   }
 

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -61,7 +61,8 @@ class EntityPass {
   Subpasses subpasses_;
   EntityPass* superpass_ = nullptr;
   Matrix xformation_;
-  Point texture_offset_;
+  /// The screen space position where this subpass' texture should be rendered.
+  Point texture_position_;
   size_t stencil_depth_ = 0u;
   std::unique_ptr<EntityPassDelegate> delegate_ =
       EntityPassDelegate::MakeDefault();
@@ -71,6 +72,16 @@ class EntityPass {
   std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
 
   std::optional<Rect> GetEntitiesCoverage() const;
+
+  /// @brief  Amends the position of the texture to be rendered for this
+  ///         subpass. The transforms of all entities under this subpass are
+  ///         also translated to ensure their positions are unchanged when the
+  ///         subpass texture is rendered to the parent pass.
+  ///
+  ///         This should only ever be called directly in cases where the
+  ///         subpass will not collapse into the parent pass, otherwise entities
+  ///         will render to the wrong location in the screen.
+  void ApplyTextureTranslation(Point translation);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPass);
 };

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -48,7 +48,7 @@ class EntityPass {
 
   EntityPass* GetSuperpass() const;
 
-  bool Render(ContentContext& renderer, RenderPass& parent_pass) const;
+  bool Render(ContentContext& renderer, RenderPass& parent_pass);
 
   void IterateAllEntities(std::function<bool(Entity&)> iterator);
 
@@ -61,6 +61,7 @@ class EntityPass {
   Subpasses subpasses_;
   EntityPass* superpass_ = nullptr;
   Matrix xformation_;
+  Point texture_offset_;
   size_t stencil_depth_ = 0u;
   std::unique_ptr<EntityPassDelegate> delegate_ =
       EntityPassDelegate::MakeDefault();

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -48,7 +48,9 @@ class EntityPass {
 
   EntityPass* GetSuperpass() const;
 
-  bool Render(ContentContext& renderer, RenderPass& parent_pass);
+  bool Render(ContentContext& renderer,
+              RenderPass& parent_pass,
+              Point position = Point()) const;
 
   void IterateAllEntities(std::function<bool(Entity&)> iterator);
 
@@ -61,8 +63,6 @@ class EntityPass {
   Subpasses subpasses_;
   EntityPass* superpass_ = nullptr;
   Matrix xformation_;
-  /// The screen space position where this subpass' texture should be rendered.
-  Point texture_position_;
   size_t stencil_depth_ = 0u;
   std::unique_ptr<EntityPassDelegate> delegate_ =
       EntityPassDelegate::MakeDefault();
@@ -72,16 +72,6 @@ class EntityPass {
   std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
 
   std::optional<Rect> GetEntitiesCoverage() const;
-
-  /// @brief  Amends the position of the texture to be rendered for this
-  ///         subpass. The transforms of all entities under this subpass are
-  ///         also translated to ensure their positions are unchanged when the
-  ///         subpass texture is rendered to the parent pass.
-  ///
-  ///         This should only ever be called directly in cases where the
-  ///         subpass will not collapse into the parent pass, otherwise entities
-  ///         will render to the wrong location in the screen.
-  void ApplyTextureTranslation(Point translation);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPass);
 };

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -779,5 +779,13 @@ TEST_F(EntityTest, SetBlendMode) {
   ASSERT_EQ(entity.GetBlendMode(), Entity::BlendMode::kClear);
 }
 
+TEST_F(EntityTest, ContentsGetBoundsForEmptyPathReturnsZero) {
+  Entity entity;
+  entity.SetContents(std::make_shared<SolidColorContents>());
+  entity.SetPath({});
+  ASSERT_TRUE(entity.GetCoverage()->IsZero());
+  ASSERT_TRUE(entity.GetTransformedPathBounds().IsZero());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -839,9 +839,16 @@ TEST(GeometryTest, RectGetPoints) {
 }
 
 TEST(GeometryTest, RectMakePointBounds) {
-  auto r = Rect::MakePointBounds({Point(1, 5), Point(4, -1), Point(0, 6)});
-  auto expected = Rect(0, -1, 4, 7);
-  ASSERT_RECT_NEAR(r, expected);
+  {
+    Rect r =
+        Rect::MakePointBounds({Point(1, 5), Point(4, -1), Point(0, 6)}).value();
+    auto expected = Rect(0, -1, 4, 7);
+    ASSERT_RECT_NEAR(r, expected);
+  }
+  {
+    std::optional<Rect> r = Rect::MakePointBounds({});
+    ASSERT_FALSE(r.has_value());
+  }
 }
 
 TEST(GeometryTest, CubicPathComponentPolylineDoesNotIncludePointOne) {

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -52,8 +52,11 @@ struct TRect {
     return TRect(0.0, 0.0, size.width, size.height);
   }
 
-  constexpr static TRect MakePointBounds(
+  constexpr static std::optional<TRect> MakePointBounds(
       const std::vector<TPoint<Type>>& points) {
+    if (points.empty()) {
+      return std::nullopt;
+    }
     auto left = points[0].x;
     auto top = points[0].y;
     auto right = points[0].x;
@@ -147,11 +150,11 @@ struct TRect {
   /// @brief  Creates a new bounding box that contains this transformed
   ///         rectangle.
   constexpr TRect TransformBounds(const Matrix& transform) const {
-    auto points = this->GetPoints();
+    auto points = GetPoints();
     for (uint i = 0; i < points.size(); i++) {
       points[i] = transform * points[i];
     }
-    return TRect::MakePointBounds({points.begin(), points.end()});
+    return TRect::MakePointBounds({points.begin(), points.end()}).value();
   }
 
   constexpr TRect Union(const TRect& o) const {

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <vector>
 
+#include "impeller/geometry/matrix.h"
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/size.h"
@@ -141,6 +142,16 @@ struct TRect {
     const auto bottom = std::max(origin.y, origin.y + size.height);
     return {TPoint(left, top), TPoint(right, top), TPoint(left, bottom),
             TPoint(right, bottom)};
+  }
+
+  /// @brief  Creates a new bounding box that contains this transformed
+  ///         rectangle.
+  constexpr TRect TransformBounds(const Matrix& transform) const {
+    auto points = this->GetPoints();
+    for (uint i = 0; i < points.size(); i++) {
+      points[i] = transform * points[i];
+    }
+    return TRect::MakePointBounds({points.begin(), points.end()});
   }
 
   constexpr TRect Union(const TRect& o) const {


### PR DESCRIPTION
I spent some time investigating a bounds-related problem today that turned out to overlap with the SaveLayer issues, and decided to take a look at @chinmaygarde's [reduced test case](https://gist.github.com/chinmaygarde/f961483ec89b61b47d907b62f4f64ec3) while I was in the neighborhood (included in this PR).

1. Don't reset the current transform when calling SaveLayer.
2. Add guard for `std::optional` in `Contents::GetBounds` when fetching the path bounds -- this is nullopt for empty paths, and so all text rendering entities were computing garbage coverage.
3. Don't apply the recorded subpass transform when compositing the subpass texture. Instead, just position the path correctly in screen space.
4. Apply the screen space bounds offset to all entities in the entity pass tree and absorb the offset in a new `texture_position_` field for rendering the subpass texture to the parent pass. Note that this field is entirely orthogonal to the `xformation_` matrix field because 1. it would be incorrect to apply the subpass transform when compositing the subpass texture and 2. we need to keep this matrix as-is for applying filters down the road.

https://user-images.githubusercontent.com/919017/161367420-cd516061-1130-4b10-9dea-114d4ac16e40.mov

https://user-images.githubusercontent.com/919017/161366332-83133dc9-0646-4ea2-8d10-286aedd6b273.mov


