### PR TITLE
Fix solid stroke contour switching + round cap smoothing, and add transparent path overdraw example

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -482,5 +482,43 @@ TEST_F(AiksTest, TransformMultipliesCorrectly) {
   // clang-format on
 }
 
+TEST_F(AiksTest, PathsShouldHaveUniformAlpha) {
+  // Compare with https://fiddle.skia.org/c/027392122bec8ac2b5d5de00a4b9bbe2
+  Canvas canvas;
+  Paint paint;
+
+  paint.color = Color::White();
+  canvas.DrawPaint(paint);
+
+  paint.color = Color::Black().WithAlpha(0.5);
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 10;
+
+  Path path = PathBuilder{}
+                  .MoveTo({20, 20})
+                  .QuadraticCurveTo({60, 20}, {60, 60})
+                  .Close()
+                  .MoveTo({60, 20})
+                  .QuadraticCurveTo({60, 60}, {20, 60})
+                  .TakePath();
+
+  canvas.Scale({3, 3});
+  for (auto join :
+       {SolidStrokeContents::Join::kBevel, SolidStrokeContents::Join::kRound,
+        SolidStrokeContents::Join::kMiter}) {
+    paint.stroke_join = join;
+    for (auto cap :
+         {SolidStrokeContents::Cap::kButt, SolidStrokeContents::Cap::kSquare,
+          SolidStrokeContents::Cap::kRound}) {
+      paint.stroke_cap = cap;
+      canvas.DrawPath(path, paint);
+      canvas.Translate({80, 0});
+    }
+    canvas.Translate({-240, 60});
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/entity/contents/solid_stroke_contents.h
+++ b/entity/contents/solid_stroke_contents.h
@@ -74,8 +74,6 @@ class SolidStrokeContents final : public Contents {
               RenderPass& pass) const override;
 
  private:
-  SmoothingApproximation arc_smoothing_approximation_;
-
   Color color_;
   Scalar stroke_size_ = 0.0;
   Scalar miter_limit_ = 4.0;


### PR DESCRIPTION
This test demonstrates a few solid stroke problems I'm investigating, but most notably: https://github.com/flutter/flutter/issues/101330

![image](https://user-images.githubusercontent.com/919017/161697240-2a8968ff-08d9-43c1-8f60-771ffa3a991b.png)

Corresponding Skia Fiddle:
https://fiddle.skia.org/c/027392122bec8ac2b5d5de00a4b9bbe2
![image](https://user-images.githubusercontent.com/919017/161686859-a2327e92-f0ec-41a7-93b0-e1b6c1674312.png)
