### PR TITLE
Wire up enhanced command buffer error reporting.

### DIFF
--- a/renderer/renderer.cc
+++ b/renderer/renderer.cc
@@ -57,6 +57,8 @@ bool Renderer::Render(std::unique_ptr<Surface> surface,
     return false;
   }
 
+  render_pass->SetLabel("Onscreen Render Pass");
+
   if (render_callback && !render_callback(*render_pass)) {
     return false;
   }


### PR DESCRIPTION
This is primarily useful in figuring out which render pass faulted vs which were merely affected by the fault. Since we already name our render passes appropriately, the traces seem fairly actionable.