### PR TITLE
Explicitly wait for subpass buffers to be scheduled.

### DIFF
--- a/renderer/backend/metal/command_buffer_mtl.mm
+++ b/renderer/backend/metal/command_buffer_mtl.mm
@@ -173,6 +173,7 @@ bool CommandBufferMTL::SubmitCommands(CompletionCallback callback) {
   }
 
   [buffer_ commit];
+  [buffer_ waitUntilScheduled];
   buffer_ = nil;
   return true;
 }


### PR DESCRIPTION
This is pending the addition of explicit synchronization primitives to
Impeller. It is unclear what the addition of such primitives would mean
to the future OpenGL ES backend.