### PR TITLE
Standardize around "coverage" terminology; make coverage optional everywhere

### DIFF
--- a/entity/contents/contents.h
+++ b/entity/contents/contents.h
@@ -36,13 +36,13 @@ class Contents {
                       const Entity& entity,
                       RenderPass& pass) const = 0;
 
-  /// @brief Get the bounding rectangle that this contents modifies in screen
-  ///        space.
-  virtual Rect GetBounds(const Entity& entity) const;
+  /// @brief Get the screen space bounding rectangle that this contents affects.
+  virtual std::optional<Rect> GetCoverage(const Entity& entity) const;
 
   /// @brief Render this contents to a texture, respecting the entity's
   ///        transform, path, stencil depth, blend mode, etc.
-  ///        The result texture size is always the size of `GetBounds(entity)`.
+  ///        The result texture size is always the size of
+  ///        `GetCoverage(entity)`.
   virtual std::optional<Snapshot> RenderToTexture(
       const ContentContext& renderer,
       const Entity& entity) const;

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -61,7 +61,7 @@ class FilterContents : public Contents {
               RenderPass& pass) const override;
 
   // |Contents|
-  Rect GetBounds(const Entity& entity) const override;
+  std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
   virtual std::optional<Snapshot> RenderToTexture(

--- a/entity/contents/filters/filter_input.cc
+++ b/entity/contents/filters/filter_input.cc
@@ -30,17 +30,17 @@ FilterInput::Variant FilterInput::GetInput() const {
   return input_;
 }
 
-Rect FilterInput::GetBounds(const Entity& entity) const {
+std::optional<Rect> FilterInput::GetCoverage(const Entity& entity) const {
   if (snapshot_) {
     return Rect(snapshot_->position, Size(snapshot_->texture->GetSize()));
   }
 
   if (auto contents = std::get_if<std::shared_ptr<Contents>>(&input_)) {
-    return contents->get()->GetBounds(entity);
+    return contents->get()->GetCoverage(entity);
   }
 
   if (auto texture = std::get_if<std::shared_ptr<Texture>>(&input_)) {
-    return entity.GetTransformedPathBounds();
+    return entity.GetPathCoverage();
   }
 
   FML_UNREACHABLE();

--- a/entity/contents/filters/filter_input.h
+++ b/entity/contents/filters/filter_input.h
@@ -42,7 +42,7 @@ class FilterInput final {
 
   Variant GetInput() const;
 
-  Rect GetBounds(const Entity& entity) const;
+  std::optional<Rect> GetCoverage(const Entity& entity) const;
 
   std::optional<Snapshot> GetSnapshot(const ContentContext& renderer,
                                       const Entity& entity) const;

--- a/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -25,7 +25,7 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
   void SetSourceOverride(FilterInput::Ref alpha_mask);
 
   // |Contents|
-  Rect GetBounds(const Entity& entity) const override;
+  std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
  private:
   // |FilterContents|

--- a/entity/entity.cc
+++ b/entity/entity.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/entity/entity.h"
 
+#include <optional>
+
 #include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/renderer/render_pass.h"
@@ -30,10 +32,10 @@ void Entity::SetPath(Path path) {
   path_ = std::move(path);
 }
 
-Rect Entity::GetTransformedPathBounds() const {
+std::optional<Rect> Entity::GetPathCoverage() const {
   auto bounds = GetPath().GetBoundingBox();
   if (!bounds.has_value()) {
-    return Rect();
+    return std::nullopt;
   }
   return bounds->TransformBounds(GetTransformation());
 }
@@ -51,7 +53,7 @@ std::optional<Rect> Entity::GetCoverage() const {
     return std::nullopt;
   }
 
-  return contents_->GetBounds(*this);
+  return contents_->GetCoverage(*this);
 }
 
 void Entity::SetContents(std::shared_ptr<Contents> contents) {

--- a/entity/entity.h
+++ b/entity/entity.h
@@ -65,7 +65,7 @@ class Entity {
 
   void SetPath(Path path);
 
-  Rect GetTransformedPathBounds() const;
+  std::optional<Rect> GetPathCoverage() const;
 
   void SetAddsToCoverage(bool adds);
 

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "flutter/testing/testing.h"
+#include "impeller/entity/contents/filters/blend_filter_contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/filters/filter_input.h"
 #include "impeller/entity/contents/solid_color_contents.h"
@@ -760,7 +761,9 @@ TEST_F(EntityTest, GaussianBlurFilter) {
     // Renders a green bounding rect of the target filter.
     Entity bounds_entity;
     bounds_entity.SetPath(
-        PathBuilder{}.AddRect(target_contents->GetBounds(entity)).TakePath());
+        PathBuilder{}
+            .AddRect(target_contents->GetCoverage(entity).value())
+            .TakePath());
     bounds_entity.SetContents(
         SolidColorContents::Make(bounds_color.Premultiply()));
     bounds_entity.SetTransformation(Matrix());
@@ -779,12 +782,12 @@ TEST_F(EntityTest, SetBlendMode) {
   ASSERT_EQ(entity.GetBlendMode(), Entity::BlendMode::kClear);
 }
 
-TEST_F(EntityTest, ContentsGetBoundsForEmptyPathReturnsZero) {
+TEST_F(EntityTest, ContentsGetBoundsForEmptyPathReturnsNullopt) {
   Entity entity;
   entity.SetContents(std::make_shared<SolidColorContents>());
   entity.SetPath({});
-  ASSERT_TRUE(entity.GetCoverage()->IsZero());
-  ASSERT_TRUE(entity.GetTransformedPathBounds().IsZero());
+  ASSERT_FALSE(entity.GetCoverage().has_value());
+  ASSERT_FALSE(entity.GetPathCoverage().has_value());
 }
 
 }  // namespace testing


### PR DESCRIPTION
We already use the term "coverage" in `Entity` and `EntityPass`, which I hadn't noticed when I started working on filters and adding per-contents `GetBounds`. This change unifies the "area of the screen that may be affected" concept around the term "coverage".

Also, we distinguish between no coverage and empty coverage everywhere by returning optionals, which we were already doing in a few places (see also [this comment](https://github.com/flutter/impeller/pull/111#discussion_r842081668)).

