### PR TITLE
Add explicit Point/Vector2 scaling methods to Matrix and Canvas

### DIFF
--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -80,6 +80,10 @@ void Canvas::Translate(const Vector3& offset) {
   Concat(Matrix::MakeTranslation(offset));
 }
 
+void Canvas::Scale(const Vector2& scale) {
+  Concat(Matrix::MakeScale(scale));
+}
+
 void Canvas::Scale(const Vector3& scale) {
   Concat(Matrix::MakeScale(scale));
 }
@@ -283,7 +287,7 @@ void Canvas::DrawTextFrame(TextFrame text_frame, Point position, Paint paint) {
   auto text_contents = std::make_shared<TextContents>();
   text_contents->SetTextFrame(std::move(text_frame));
   text_contents->SetGlyphAtlas(std::move(lazy_glyph_atlas));
-  text_contents->SetColor(paint.color.Premultiply());
+  text_contents->SetColor(paint.color);
 
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation() *

--- a/aiks/canvas.h
+++ b/aiks/canvas.h
@@ -52,6 +52,8 @@ class Canvas {
 
   void Translate(const Vector3& offset);
 
+  void Scale(const Vector2& scale);
+
   void Scale(const Vector3& scale);
 
   void Skew(Scalar sx, Scalar sy);

--- a/entity/contents/text_contents.cc
+++ b/entity/contents/text_contents.cc
@@ -80,7 +80,7 @@ bool TextContents::Render(const ContentContext& renderer,
   frame_info.atlas_size =
       Point{static_cast<Scalar>(atlas->GetTexture()->GetSize().width),
             static_cast<Scalar>(atlas->GetTexture()->GetSize().height)};
-  frame_info.text_color = ToVector(color_);
+  frame_info.text_color = ToVector(color_.Premultiply());
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   // Common fragment uniforms for all glyphs.

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -37,13 +37,24 @@ TEST(GeometryTest, RotationMatrix) {
 }
 
 TEST(GeometryTest, InvertMultMatrix) {
-  auto rotation = Matrix::MakeRotationZ(Radians{M_PI_4});
-  auto invert = rotation.Invert();
-  auto expect = Matrix{0.707, -0.707, 0, 0,  //
-                       0.707, 0.707,  0, 0,  //
-                       0,     0,      1, 0,  //
-                       0,     0,      0, 1};
-  ASSERT_MATRIX_NEAR(invert, expect);
+  {
+    auto rotation = Matrix::MakeRotationZ(Radians{M_PI_4});
+    auto invert = rotation.Invert();
+    auto expect = Matrix{0.707, -0.707, 0, 0,  //
+                         0.707, 0.707,  0, 0,  //
+                         0,     0,      1, 0,  //
+                         0,     0,      0, 1};
+    ASSERT_MATRIX_NEAR(invert, expect);
+  }
+  {
+    auto scale = Matrix::MakeScale(Vector2{2, 4});
+    auto invert = scale.Invert();
+    auto expect = Matrix{0.5, 0,    0, 0,  //
+                         0,   0.25, 0, 0,  //
+                         0,   0,    1, 0,  //
+                         0,   0,    0, 1};
+    ASSERT_MATRIX_NEAR(invert, expect);
+  }
 }
 
 TEST(GeometryTest, MutliplicationMatrix) {

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -80,6 +80,10 @@ struct Matrix {
     // clang-format on
   }
 
+  static constexpr Matrix MakeScale(const Vector2& s) {
+    return MakeScale(Vector3(s.x, s.y, 1.0));
+  }
+
   static constexpr Matrix MakeSkew(Scalar sx, Scalar sy) {
     // clang-format off
     return Matrix(1.0, sy , 0.0, 0.0,


### PR DESCRIPTION
Add an explicit Vector2 scale override in `Matrix` and `Canvas`.

So I ran into some confusion while adding imgui elements to the test for https://github.com/flutter/flutter/issues/101330. I set the canvas scale with `canvas.Scale({3, 3})`, which scaled everything correctly. However, to my dismay, `canvas.GetCurrentTransformation().Invert()` produced an identity matrix. The problem was that `canvas.Scale({x, y})` matches `Canvas::Scale(Vector3{x, y})`, and so the Z component of the Z basis vector gets set to zero, which means the determinant ends up being zero, which makes computing the inverse nonsensical. Having this explicit override makes this mistake much less likely.

(Also, drive-by fix: Move the text contents color premultiply into the render method for consistency with other contents)