### PR TITLE
Fix solid stroke overdraw

### DIFF
--- a/entity/contents/solid_color_contents.cc
+++ b/entity/contents/solid_color_contents.cc
@@ -53,7 +53,7 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   using VS = SolidFillPipeline::VertexShader;
 
   Command cmd;
-  cmd.label = "SolidFill";
+  cmd.label = "Solid Fill";
   cmd.pipeline =
       renderer.GetSolidFillPipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
@@ -63,7 +63,7 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
                    entity.GetTransformation();
-  frame_info.color = color_;
+  frame_info.color = color_.Premultiply();
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   cmd.primitive_type = PrimitiveType::kTriangle;

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -752,8 +752,7 @@ TEST_F(EntityTest, GaussianBlurFilter) {
     // unfiltered input.
     Entity cover_entity;
     cover_entity.SetPath(PathBuilder{}.AddRect(rect).TakePath());
-    cover_entity.SetContents(
-        SolidColorContents::Make(cover_color.Premultiply()));
+    cover_entity.SetContents(SolidColorContents::Make(cover_color));
     cover_entity.SetTransformation(ctm);
 
     cover_entity.Render(context, pass);
@@ -764,8 +763,7 @@ TEST_F(EntityTest, GaussianBlurFilter) {
         PathBuilder{}
             .AddRect(target_contents->GetCoverage(entity).value())
             .TakePath());
-    bounds_entity.SetContents(
-        SolidColorContents::Make(bounds_color.Premultiply()));
+    bounds_entity.SetContents(SolidColorContents::Make(bounds_color));
     bounds_entity.SetTransformation(Matrix());
 
     bounds_entity.Render(context, pass);


### PR DESCRIPTION
Relies on changes in https://github.com/flutter/impeller/pull/120.

Fixes https://github.com/flutter/flutter/issues/101330.

* Render non-opaque solid strokes, incrementing the stencil to avoid overdraw.
* Return the stencil to its previous state by drawing a clip restore.

Before:
![image](https://user-images.githubusercontent.com/919017/162120840-90808531-6c4d-4bbc-95de-08a4778f355c.png)

After:

https://user-images.githubusercontent.com/919017/162120700-b34e7adc-a3ab-4ad6-9613-fcfcee7d9e5b.mov


