### PR TITLE
Standardize around blur sigma<->radius conversion factor

### DIFF
--- a/entity/contents/filters/filter_contents.cc
+++ b/entity/contents/filters/filter_contents.cc
@@ -61,12 +61,14 @@ std::shared_ptr<FilterContents> FilterContents::MakeBlend(
 
 std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
     FilterInput::Ref input,
-    Vector2 blur_vector,
+    Sigma sigma,
+    Vector2 direction,
     BlurStyle blur_style,
     FilterInput::Ref source_override) {
   auto blur = std::make_shared<DirectionalGaussianBlurFilterContents>();
   blur->SetInputs({input});
-  blur->SetBlurVector(blur_vector);
+  blur->SetSigma(sigma);
+  blur->SetDirection(direction);
   blur->SetBlurStyle(blur_style);
   blur->SetSourceOverride(source_override);
   return blur;
@@ -74,13 +76,13 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
 
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     FilterInput::Ref input,
-    Scalar sigma_x,
-    Scalar sigma_y,
+    Sigma sigma_x,
+    Sigma sigma_y,
     BlurStyle blur_style) {
-  auto x_blur =
-      MakeDirectionalGaussianBlur(input, Point(sigma_x, 0), BlurStyle::kNormal);
-  auto y_blur = MakeDirectionalGaussianBlur(
-      FilterInput::Make(x_blur), Point(0, sigma_y), blur_style, input);
+  auto x_blur = MakeDirectionalGaussianBlur(input, sigma_x, Point(1, 0),
+                                            BlurStyle::kNormal);
+  auto y_blur = MakeDirectionalGaussianBlur(FilterInput::Make(x_blur), sigma_y,
+                                            Point(0, 1), blur_style, input);
   return y_blur;
 }
 

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -29,19 +29,51 @@ class FilterContents : public Contents {
     kInner,
   };
 
+  /// 1 / sqrt(3)
+  /// This is the Gaussian blur standard deviation cutoff expected by Flutter:
+  /// https://api.flutter.dev/flutter/dart-ui/Shadow/convertRadiusToSigma.html
+  constexpr static float kBlurSigmaScale = 0.57735026919;
+
+  struct Radius;
+
+  struct Sigma {
+    Scalar sigma = 0.0;
+
+    constexpr Sigma() = default;
+
+    explicit constexpr Sigma(Scalar p_sigma) : sigma(p_sigma) {}
+
+    constexpr operator Radius() const {
+      return Radius{sigma > 0.5f ? (sigma - 0.5f) / kBlurSigmaScale : 0.0f};
+    };
+  };
+
+  struct Radius {
+    Scalar radius = 0.0;
+
+    constexpr Radius() = default;
+
+    explicit constexpr Radius(Scalar p_radius) : radius(p_radius) {}
+
+    constexpr operator Sigma() const {
+      return Sigma{radius > 0 ? kBlurSigmaScale * radius + 0.5f : 0.0f};
+    };
+  };
+
   static std::shared_ptr<FilterContents> MakeBlend(Entity::BlendMode blend_mode,
                                                    FilterInput::Vector inputs);
 
   static std::shared_ptr<FilterContents> MakeDirectionalGaussianBlur(
       FilterInput::Ref input,
-      Vector2 blur_vector,
+      Sigma sigma,
+      Vector2 direction,
       BlurStyle blur_style = BlurStyle::kNormal,
       FilterInput::Ref alpha_mask = nullptr);
 
   static std::shared_ptr<FilterContents> MakeGaussianBlur(
       FilterInput::Ref input,
-      Scalar sigma_x,
-      Scalar sigma_y,
+      Sigma sigma_x,
+      Sigma sigma_y,
       BlurStyle blur_style = BlurStyle::kNormal);
 
   FilterContents();

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -29,13 +29,26 @@ class FilterContents : public Contents {
     kInner,
   };
 
-  /// 1 / sqrt(3)
-  /// This is the Gaussian blur standard deviation cutoff expected by Flutter:
+  /// For filters that use a Gaussian distribution, this is the `Radius` size to
+  /// use per `Sigma` (standard deviation).
+  ///
+  /// This cutoff (sqrt(3)) is taken from Flutter and Skia (where the
+  /// multiplicative inverse of this constant is used (1 / sqrt(3)):
   /// https://api.flutter.dev/flutter/dart-ui/Shadow/convertRadiusToSigma.html
-  constexpr static float kBlurSigmaScale = 0.57735026919;
+  ///
+  /// In practice, this value is somewhat arbitrary, and can be changed to a
+  /// higher number to integrate more of the Gaussian function and render higher
+  /// quality blurs (with exponentially diminishing returns for the same sigma
+  /// input). Making this value any lower results in a noticable loss of
+  /// quality in the blur.
+  constexpr static float kKernelRadiusPerSigma = 1.73205080757;
 
   struct Radius;
 
+  /// @brief  In filters that use Gaussian distributions, "sigma" is a size of
+  ///         one standard deviation in terms of the local space pixel grid of
+  ///         the filter input. In other words, this determines how wide the
+  ///         distribution stretches.
   struct Sigma {
     Scalar sigma = 0.0;
 
@@ -44,10 +57,17 @@ class FilterContents : public Contents {
     explicit constexpr Sigma(Scalar p_sigma) : sigma(p_sigma) {}
 
     constexpr operator Radius() const {
-      return Radius{sigma > 0.5f ? (sigma - 0.5f) / kBlurSigmaScale : 0.0f};
+      return Radius{sigma > 0.5f ? (sigma - 0.5f) * kKernelRadiusPerSigma
+                                 : 0.0f};
     };
   };
 
+  /// @brief  For convolution filters, the "radius" is the size of the
+  ///         convolution kernel to use on the local space pixel grid of the
+  ///         filter input.
+  ///         For Gaussian blur kernels, this unit has a linear
+  ///         relationship with `Sigma`. See `kKernelRadiusPerSigma` for
+  ///         details on how this relationship works.
   struct Radius {
     Scalar radius = 0.0;
 
@@ -56,7 +76,7 @@ class FilterContents : public Contents {
     explicit constexpr Radius(Scalar p_radius) : radius(p_radius) {}
 
     constexpr operator Sigma() const {
-      return Sigma{radius > 0 ? kBlurSigmaScale * radius + 0.5f : 0.0f};
+      return Sigma{radius > 0 ? radius / kKernelRadiusPerSigma + 0.5f : 0.0f};
     };
   };
 

--- a/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -24,6 +24,10 @@ DirectionalGaussianBlurFilterContents::
 
 void DirectionalGaussianBlurFilterContents::SetSigma(Sigma sigma) {
   if (sigma.sigma < kEhCloseEnough) {
+    // This cutoff is an implementation detail of the blur that's tied to the
+    // fragment shader. When the blur is set to 0, having a value slightly above
+    // zero makes the shader do 1 finite sample to pass the image through with
+    // no blur (while retaining correct alpha mask behavior).
     blur_sigma_ = Sigma{kEhCloseEnough};
     return;
   }

--- a/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -22,12 +22,19 @@ DirectionalGaussianBlurFilterContents::DirectionalGaussianBlurFilterContents() =
 DirectionalGaussianBlurFilterContents::
     ~DirectionalGaussianBlurFilterContents() = default;
 
-void DirectionalGaussianBlurFilterContents::SetBlurVector(Vector2 blur_vector) {
-  if (blur_vector.GetLengthSquared() < kEhCloseEnough) {
-    blur_vector_ = Vector2(0, kEhCloseEnough);
+void DirectionalGaussianBlurFilterContents::SetSigma(Sigma sigma) {
+  if (sigma.sigma < kEhCloseEnough) {
+    blur_sigma_ = Sigma{kEhCloseEnough};
     return;
   }
-  blur_vector_ = blur_vector;
+  blur_sigma_ = sigma;
+}
+
+void DirectionalGaussianBlurFilterContents::SetDirection(Vector2 direction) {
+  blur_direction_ = direction.Normalize();
+  if (blur_direction_.IsZero()) {
+    blur_direction_ = Vector2(0, 1);
+  }
 }
 
 void DirectionalGaussianBlurFilterContents::SetBlurStyle(BlurStyle blur_style) {
@@ -93,8 +100,8 @@ bool DirectionalGaussianBlurFilterContents::RenderFilter(
     return false;
   }
 
-  auto transformed_blur =
-      entity.GetTransformation().TransformDirection(blur_vector_);
+  auto transformed_blur = entity.GetTransformation().TransformDirection(
+      blur_direction_ * blur_sigma_.sigma);
 
   // LTRB
   Scalar uv[4] = {
@@ -142,7 +149,8 @@ bool DirectionalGaussianBlurFilterContents::RenderFilter(
 
   VS::FrameInfo frame_info;
   frame_info.texture_size = Point(input_bounds->size);
-  frame_info.blur_radius = transformed_blur.GetLength();
+  frame_info.blur_sigma = transformed_blur.GetLength();
+  frame_info.blur_radius = Radius{Sigma{frame_info.blur_sigma}}.radius;
   frame_info.blur_direction = transformed_blur.Normalize();
   frame_info.src_factor = src_color_factor_;
   frame_info.inner_blur_factor = inner_blur_factor_;
@@ -174,10 +182,14 @@ std::optional<Rect> DirectionalGaussianBlurFilterContents::GetCoverage(
     return std::nullopt;
   }
 
-  auto transformed_blur =
-      entity.GetTransformation().TransformDirection(blur_vector_).Abs();
-  auto extent = bounds->size + transformed_blur * 2;
-  return Rect(bounds->origin - transformed_blur, Size(extent.x, extent.y));
+  auto transformed_blur_vector =
+      entity.GetTransformation()
+          .TransformDirection(blur_direction_ *
+                              ceil(Radius{blur_sigma_}.radius))
+          .Abs();
+  auto extent = bounds->size + transformed_blur_vector * 2;
+  return Rect(bounds->origin - transformed_blur_vector,
+              Size(extent.x, extent.y));
 }
 
 }  // namespace impeller

--- a/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -18,7 +18,9 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
 
   ~DirectionalGaussianBlurFilterContents() override;
 
-  void SetBlurVector(Vector2 blur_vector);
+  void SetSigma(Sigma sigma);
+
+  void SetDirection(Vector2 direction);
 
   void SetBlurStyle(BlurStyle blur_style);
 
@@ -34,8 +36,8 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
                     const Entity& entity,
                     RenderPass& pass,
                     const Rect& bounds) const override;
-
-  Vector2 blur_vector_;
+  Sigma blur_sigma_;
+  Vector2 blur_direction_;
   BlurStyle blur_style_ = BlurStyle::kNormal;
   bool src_color_factor_ = false;
   bool inner_blur_factor_ = true;

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -729,7 +729,8 @@ TEST_F(EntityTest, GaussianBlurFilter) {
         Entity::BlendMode::kPlus, FilterInput::Make({boston, bridge, bridge}));
 
     auto blur = FilterContents::MakeGaussianBlur(
-        FilterInput::Make(blend), blur_amount[0], blur_amount[1],
+        FilterInput::Make(blend), FilterContents::Sigma{blur_amount[0]},
+        FilterContents::Sigma{blur_amount[1]},
         blur_styles[selected_blur_style]);
 
     ISize input_size = boston->GetSize();

--- a/entity/shaders/gaussian_blur.vert
+++ b/entity/shaders/gaussian_blur.vert
@@ -7,6 +7,7 @@ uniform FrameInfo {
   vec2 texture_size;
 
   vec2 blur_direction;
+  float blur_sigma;
   float blur_radius;
 
   float src_factor;
@@ -23,6 +24,7 @@ out vec2 v_texture_coords;
 out vec2 v_src_texture_coords;
 out vec2 v_texture_size;
 out vec2 v_blur_direction;
+out float v_blur_sigma;
 out float v_blur_radius;
 out float v_src_factor;
 out float v_inner_blur_factor;
@@ -34,6 +36,7 @@ void main() {
   v_src_texture_coords = src_texture_coords;
   v_texture_size = frame_info.texture_size;
   v_blur_direction = frame_info.blur_direction;
+  v_blur_sigma = frame_info.blur_sigma;
   v_blur_radius = frame_info.blur_radius;
   v_src_factor = frame_info.src_factor;
   v_inner_blur_factor = frame_info.inner_blur_factor;


### PR DESCRIPTION
Use the constant that Flutter + Skia use for the kernel radius/distribution sample cutoff: `1/sqrt(3)`. The cutoff is just barely visible. In practice, we're free to make this conversion factor whatever we want (with diminishing returns).
Making it 3, for example, would cause the kernel convolution to cover at least 99.9% of the gaussian distribution.

Also fixes a mistake in the gaussian function (use the correct constant `1/sqrt(2*pi)` instead of `1/(2*pi)`).