### PR TITLE
Remove extra premultiply from solid stroke/fill

### DIFF
--- a/aiks/paint.cc
+++ b/aiks/paint.cc
@@ -16,12 +16,12 @@ std::shared_ptr<Contents> Paint::CreateContentsForEntity() const {
   switch (style) {
     case Style::kFill: {
       auto solid_color = std::make_shared<SolidColorContents>();
-      solid_color->SetColor(color.Premultiply());
+      solid_color->SetColor(color);
       return solid_color;
     }
     case Style::kStroke: {
       auto solid_stroke = std::make_shared<SolidStrokeContents>();
-      solid_stroke->SetColor(color.Premultiply());
+      solid_stroke->SetColor(color);
       solid_stroke->SetStrokeSize(stroke_width);
       solid_stroke->SetStrokeMiter(stroke_miter);
       solid_stroke->SetStrokeCap(stroke_cap);

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -49,7 +49,7 @@ TEST_F(EntityTest, ThreeStrokesInOnePath) {
   Entity entity;
   entity.SetPath(path);
   auto contents = std::make_unique<SolidStrokeContents>();
-  contents->SetColor(Color::Red().Premultiply());
+  contents->SetColor(Color::Red());
   contents->SetStrokeSize(5.0);
   entity.SetContents(std::move(contents));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
@@ -79,7 +79,7 @@ TEST_F(EntityTest, TriangleInsideASquare) {
     Entity entity;
     entity.SetPath(path);
     auto contents = std::make_unique<SolidStrokeContents>();
-    contents->SetColor(Color::Red().Premultiply());
+    contents->SetColor(Color::Red());
     contents->SetStrokeSize(20.0);
     entity.SetContents(std::move(contents));
 
@@ -117,7 +117,7 @@ TEST_F(EntityTest, StrokeCapAndJoinTest) {
     auto create_contents = [width = width](SolidStrokeContents::Cap cap,
                                            SolidStrokeContents::Join join) {
       auto contents = std::make_unique<SolidStrokeContents>();
-      contents->SetColor(Color::Red().Premultiply());
+      contents->SetColor(Color::Red());
       contents->SetStrokeSize(width);
       contents->SetStrokeCap(cap);
       contents->SetStrokeJoin(join);


### PR DESCRIPTION
I started moving all the premultiplying of solid colors into Contents Render methods for consistency and accidentally added part of that change to https://github.com/flutter/impeller/pull/121, so at HEAD we're doubling up on the premultiply in the Render method for `Solid[Color|Stroke]Contents`.