### PR TITLE
No newline in depfile output, which seems to confuse ninja

### DIFF
--- a/compiler/compiler.cc
+++ b/compiler/compiler.cc
@@ -458,7 +458,7 @@ std::unique_ptr<fml::Mapping> Compiler::CreateDepfileContents(
   const auto dependencies = GetDependencyNames(" ");
 
   std::stringstream stream;
-  stream << targets << ":\n\t" << dependencies << "\n";
+  stream << targets << ": " << dependencies << "\n";
 
   auto contents = std::make_shared<std::string>(stream.str());
   return std::make_unique<fml::NonOwnedMapping>(


### PR DESCRIPTION
Fixes the issue I'm seeing locally where incremental builds end up giving errors like:

```
ninja: Entering directory `out/host_debug_unopt'
ninja: error: gen/flutter/impeller/entity/gradient_fill.frag.d: depfile mentions '../../flutter/impeller/entity/shaders/gradient_fill.frag' as an output, but no such output was declared
```

The depfile formatting goes from

```
gen/flutter/impeller/entity/gradient_fill.frag.metal: 
  ../../flutter/impeller/entity/shaders/gradient_fill.frag
```

to

```
gen/flutter/impeller/entity/gradient_fill.frag.metal: ../../flutter/impeller/entity/shaders/gradient_fill.frag
```

With the newline, ninja sometimes seems to think that the dependency is actually an ouput.