### PR TITLE
Fix Path::GetBoundingBox crash for cubics

### DIFF
--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -315,6 +315,17 @@ TEST(GeometryTest, BoundingBoxOfCompositePathIsCorrect) {
   ASSERT_RECT_NEAR(actual.value(), expected);
 }
 
+TEST(GeometryTest, PathGetBoundingBoxForCubicWithNoDerivativeRootsIsCorrect) {
+  PathBuilder builder;
+  // Straight diagonal line.
+  builder.AddCubicCurve({0, 1}, {2, 3}, {4, 5}, {6, 7});
+  auto path = builder.TakePath();
+  auto actual = path.GetBoundingBox();
+  auto expected = Rect::MakeLTRB(0, 1, 6, 7);
+  ASSERT_TRUE(actual.has_value());
+  ASSERT_RECT_NEAR(actual.value(), expected);
+}
+
 TEST(GeometryTest, CanGenerateMipCounts) {
   ASSERT_EQ((Size{128, 128}.MipCount()), 7u);
   ASSERT_EQ((Size{128, 256}.MipCount()), 8u);

--- a/geometry/path.cc
+++ b/geometry/path.cc
@@ -322,6 +322,10 @@ std::optional<std::pair<Point, Point>> Path::GetMinMaxCoveragePoints() const {
     clamp(cubic.Extrema());
   }
 
+  if (!min.has_value() || !max.has_value()) {
+    return std::nullopt;
+  }
+
   return std::make_pair(min.value(), max.value());
 }
 

--- a/geometry/path_component.cc
+++ b/geometry/path_component.cc
@@ -408,7 +408,7 @@ std::vector<Point> CubicPathComponent::Extrema() const {
   CubicPathBoundingPopulateValues(values, p1.x, cp1.x, cp2.x, p2.x);
   CubicPathBoundingPopulateValues(values, p1.y, cp1.y, cp2.y, p2.y);
 
-  std::vector<Point> points;
+  std::vector<Point> points = {p1, p2};
 
   for (const auto& value : values) {
     points.emplace_back(Solve(value));


### PR DESCRIPTION
Ran into this while making an override for the solid stroke coverage.

We incorporate the local min/max points for cubics by finding the roots of the first derivative of the x/y component cubics, but this doesn't end up enclosing the first/last point in most cases.

Demo of the issue (with the optional check to prevent the crash):

https://user-images.githubusercontent.com/919017/162394845-7b923333-0b32-47dc-867e-45a426367ebb.mov

The test I added creates a cubic with no derivative roots (it's just a line), which was causing `Path::GetBoundingBox` to crash before this change.
