### PR TITLE
Compute text coverage; use blend mode in savelayer; conservative pass collapse/elision behavior

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -418,6 +418,27 @@ TEST_F(AiksTest, CanRenderEmojiTextFrame) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_F(AiksTest, CanRenderTextInSaveLayer) {
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color::White()});
+  canvas.Translate({100, 100});
+  canvas.Scale(Vector2{0.5, 0.5});
+
+  // Blend the layer with the parent pass using kClear to expose the coverage.
+  canvas.SaveLayer({.blend_mode = Entity::BlendMode::kClear});
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), canvas, "the quick brown fox jumped over the lazy dog!.?",
+      "Roboto-Regular.ttf"));
+  canvas.Restore();
+
+  // Render the text again over the cleared coverage rect.
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), canvas, "the quick brown fox jumped over the lazy dog!.?",
+      "Roboto-Regular.ttf"));
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_F(AiksTest, CanDrawPaint) {
   Paint paint;
   paint.color = Color::MediumTurquoise();

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -141,9 +141,10 @@ void Canvas::DrawCircle(Point center, Scalar radius, Paint paint) {
 
 void Canvas::SaveLayer(Paint paint, std::optional<Rect> bounds) {
   GetCurrentPass().SetDelegate(
-      std::make_unique<PaintPassDelegate>(std::move(paint), bounds));
+      std::make_unique<PaintPassDelegate>(paint, bounds));
 
   Save(true);
+  GetCurrentPass().SetBlendMode(paint.blend_mode);
 
   if (bounds.has_value()) {
     // Render target switches due to a save layer can be elided. In such cases

--- a/aiks/paint_pass_delegate.cc
+++ b/aiks/paint_pass_delegate.cc
@@ -22,12 +22,12 @@ std::optional<Rect> PaintPassDelegate::GetCoverageRect() {
 
 // |EntityPassDelgate|
 bool PaintPassDelegate::CanElide() {
-  return paint_.color.IsTransparent();
+  return paint_.blend_mode == Entity::BlendMode::kDestination;
 }
 
 // |EntityPassDelgate|
 bool PaintPassDelegate::CanCollapseIntoParentPass() {
-  return paint_.color.IsOpaque();
+  return false;
 }
 
 // |EntityPassDelgate|

--- a/entity/contents/text_contents.cc
+++ b/entity/contents/text_contents.cc
@@ -48,6 +48,10 @@ void TextContents::SetColor(Color color) {
   color_ = color;
 }
 
+std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
+  return frame_.GetBounds().TransformBounds(entity.GetTransformation());
+}
+
 bool TextContents::Render(const ContentContext& renderer,
                           const Entity& entity,
                           RenderPass& pass) const {

--- a/entity/contents/text_contents.cc
+++ b/entity/contents/text_contents.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/entity/contents/text_contents.h"
 
+#include <optional>
+
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/path_builder.h"
@@ -49,7 +51,11 @@ void TextContents::SetColor(Color color) {
 }
 
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
-  return frame_.GetBounds().TransformBounds(entity.GetTransformation());
+  auto bounds = frame_.GetBounds();
+  if (!bounds.has_value()) {
+    return std::nullopt;
+  }
+  return bounds->TransformBounds(entity.GetTransformation());
 }
 
 bool TextContents::Render(const ContentContext& renderer,

--- a/entity/contents/text_contents.h
+++ b/entity/contents/text_contents.h
@@ -35,6 +35,9 @@ class TextContents final : public Contents {
   void SetColor(Color color);
 
   // |Contents|
+  std::optional<Rect> GetCoverage(const Entity& entity) const override;
+
+  // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;

--- a/entity/entity_pass.cc
+++ b/entity/entity_pass.cc
@@ -210,6 +210,7 @@ bool EntityPass::Render(ContentContext& renderer,
                        .TakePath());
     entity.SetContents(std::move(offscreen_texture_contents));
     entity.SetStencilDepth(stencil_depth_);
+    entity.SetBlendMode(subpass->blend_mode_);
     // Once we have filters being applied for SaveLayer, some special sauce
     // may be needed here (or in PaintPassDelegate) to ensure the filter
     // parameters are transformed by the `xformation_` matrix, while continuing
@@ -255,6 +256,10 @@ void EntityPass::SetTransformation(Matrix xformation) {
 
 void EntityPass::SetStencilDepth(size_t stencil_depth) {
   stencil_depth_ = stencil_depth;
+}
+
+void EntityPass::SetBlendMode(Entity::BlendMode blend_mode) {
+  blend_mode_ = blend_mode;
 }
 
 }  // namespace impeller

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -58,12 +58,15 @@ class EntityPass {
 
   void SetStencilDepth(size_t stencil_depth);
 
+  void SetBlendMode(Entity::BlendMode blend_mode);
+
  private:
   Entities entities_;
   Subpasses subpasses_;
   EntityPass* superpass_ = nullptr;
   Matrix xformation_;
   size_t stencil_depth_ = 0u;
+  Entity::BlendMode blend_mode_ = Entity::BlendMode::kSourceOver;
   std::unique_ptr<EntityPassDelegate> delegate_ =
       EntityPassDelegate::MakeDefault();
   std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_ =

--- a/typographer/backends/skia/text_frame_skia.cc
+++ b/typographer/backends/skia/text_frame_skia.cc
@@ -36,10 +36,6 @@ TextFrame TextFrameFromTextBlob(sk_sp<SkTextBlob> blob, Scalar scale) {
 
   TextFrame frame;
 
-  auto bounds = blob->bounds();
-  frame.SetBounds(
-      Rect(bounds.x(), bounds.y(), bounds.width(), bounds.height()));
-
   for (SkTextBlobRunIterator run(blob.get()); !run.done(); run.next()) {
     TextRun text_run(ToFont(run.font(), scale));
     const auto glyph_count = run.glyphCount();

--- a/typographer/backends/skia/text_frame_skia.cc
+++ b/typographer/backends/skia/text_frame_skia.cc
@@ -29,13 +29,16 @@ static Font ToFont(const SkFont& font, Scalar scale) {
   return Font{std::move(typeface), std::move(metrics)};
 }
 
-TextFrame TextFrameFromTextBlob(sk_sp<SkTextBlob> blob,
-                                Scalar scale) {
+TextFrame TextFrameFromTextBlob(sk_sp<SkTextBlob> blob, Scalar scale) {
   if (!blob) {
     return {};
   }
 
   TextFrame frame;
+
+  auto bounds = blob->bounds();
+  frame.SetBounds(
+      Rect(bounds.x(), bounds.y(), bounds.width(), bounds.height()));
 
   for (SkTextBlobRunIterator run(blob.get()); !run.done(); run.next()) {
     TextRun text_run(ToFont(run.font(), scale));

--- a/typographer/text_frame.cc
+++ b/typographer/text_frame.cc
@@ -10,6 +10,14 @@ TextFrame::TextFrame() = default;
 
 TextFrame::~TextFrame() = default;
 
+const Rect& TextFrame::GetBounds() const {
+  return bounds_;
+}
+
+void TextFrame::SetBounds(Rect bounds) {
+  bounds_ = std::move(bounds);
+}
+
 bool TextFrame::AddTextRun(TextRun run) {
   if (!run.IsValid()) {
     return false;

--- a/typographer/text_frame.cc
+++ b/typographer/text_frame.cc
@@ -10,12 +10,19 @@ TextFrame::TextFrame() = default;
 
 TextFrame::~TextFrame() = default;
 
-const Rect& TextFrame::GetBounds() const {
-  return bounds_;
-}
+std::optional<Rect> TextFrame::GetBounds() const {
+  std::optional<Rect> result;
 
-void TextFrame::SetBounds(Rect bounds) {
-  bounds_ = std::move(bounds);
+  for (const auto& run : runs_) {
+    const auto glyph_bounds = run.GetFont().GetMetrics().GetBoundingBox();
+    for (const auto& glyph_position : run.GetGlyphPositions()) {
+      Vector2 position = glyph_position.position * Vector2();
+      Rect glyph_rect = Rect(position + glyph_bounds.origin, glyph_bounds.size);
+      result = result.has_value() ? result->Union(glyph_rect) : glyph_rect;
+    }
+  }
+
+  return result;
 }
 
 bool TextFrame::AddTextRun(TextRun run) {

--- a/typographer/text_frame.h
+++ b/typographer/text_frame.h
@@ -21,6 +21,9 @@ class TextFrame {
 
   ~TextFrame();
 
+  const Rect& GetBounds() const;
+  void SetBounds(Rect bounds);
+
   //----------------------------------------------------------------------------
   /// @brief      The number of runs in this text frame.
   ///
@@ -45,6 +48,7 @@ class TextFrame {
   const std::vector<TextRun>& GetRuns() const;
 
  private:
+  Rect bounds_;
   std::vector<TextRun> runs_;
 };
 

--- a/typographer/text_frame.h
+++ b/typographer/text_frame.h
@@ -21,8 +21,13 @@ class TextFrame {
 
   ~TextFrame();
 
-  const Rect& GetBounds() const;
-  void SetBounds(Rect bounds);
+  //----------------------------------------------------------------------------
+  /// @brief      The conservative bounding box for this text frame.
+  ///
+  /// @return     The bounds rectangle. If there are no glyphs in this text
+  ///             frame, std::nullopt is returned.
+  ///
+  std::optional<Rect> GetBounds() const;
 
   //----------------------------------------------------------------------------
   /// @brief      The number of runs in this text frame.
@@ -48,7 +53,6 @@ class TextFrame {
   const std::vector<TextRun>& GetRuns() const;
 
  private:
-  Rect bounds_;
   std::vector<TextRun> runs_;
 };
 


### PR DESCRIPTION
Compute text coverage by transforming the bounds pulled from the Skia text blob. Before it was just zero because we hand the entities empty paths when rendering text.

To write the Aiks test, some light yak shaving was necessary:
* Pipe blend mode through entity pass/save layer.
* Make subpass collapse/elision behavior more conservative... We can elide for `kDestination` blend, but the paint color doesn't help with either decision AFAIKT? Only by looking at all of the entities' blend modes would we actually be able to know the answer to this (if a pass and all of its children (subpasses and entities) have the same additive blend mode and no filter is present, we can collapse). I suggest we keep a "can_collapse" flag per-pass and do this check as entities are appended to the pass, so that we don't have to do another loop over the entities. Will add something simple like this in a follow-up.

Another savelayer problem I noticed: We draw all of the subpasses on top of the entities in the parent pass (i.e. savelayers go on top of everything else, even things drawn after the `canvas.Restore()`). Putting a cap on the yak shave here for now though. ;)