### PR TITLE
Filters: Replace Snapshot position with a full transform

### DIFF
--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -33,7 +33,7 @@ std::optional<Rect> Contents::GetCoverage(const Entity& entity) const {
   return entity.GetPathCoverage();
 }
 
-std::optional<Snapshot> Contents::RenderToTexture(
+std::optional<Snapshot> Contents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity) const {
   auto bounds = GetCoverage(entity);
@@ -58,7 +58,8 @@ std::optional<Snapshot> Contents::RenderToTexture(
     return std::nullopt;
   }
 
-  return Snapshot{.texture = texture, .position = bounds->origin};
+  return Snapshot{.texture = texture,
+                  .transform = Matrix::MakeTranslation(bounds->origin)};
 }
 
 }  // namespace impeller

--- a/entity/contents/contents.h
+++ b/entity/contents/contents.h
@@ -39,11 +39,11 @@ class Contents {
   /// @brief Get the screen space bounding rectangle that this contents affects.
   virtual std::optional<Rect> GetCoverage(const Entity& entity) const;
 
-  /// @brief Render this contents to a texture, respecting the entity's
+  /// @brief Render this contents to a snapshot, respecting the entity's
   ///        transform, path, stencil depth, blend mode, etc.
   ///        The result texture size is always the size of
   ///        `GetCoverage(entity)`.
-  virtual std::optional<Snapshot> RenderToTexture(
+  virtual std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity) const;
 

--- a/entity/contents/filters/blend_filter_contents.h
+++ b/entity/contents/filters/blend_filter_contents.h
@@ -16,7 +16,7 @@ class BlendFilterContents : public FilterContents {
                          const ContentContext& renderer,
                          const Entity& entity,
                          RenderPass& pass,
-                         const Rect& bounds)>;
+                         const Rect& coverage)>;
 
   BlendFilterContents();
 
@@ -30,7 +30,7 @@ class BlendFilterContents : public FilterContents {
                     const ContentContext& renderer,
                     const Entity& entity,
                     RenderPass& pass,
-                    const Rect& bounds) const override;
+                    const Rect& coverage) const override;
 
   Entity::BlendMode blend_mode_;
   AdvancedBlendProc advanced_blend_proc_;

--- a/entity/contents/filters/filter_contents.cc
+++ b/entity/contents/filters/filter_contents.cc
@@ -50,7 +50,9 @@ std::shared_ptr<FilterContents> FilterContents::MakeBlend(
       new_blend = std::make_shared<BlendFilterContents>();
       new_blend->SetInputs({blend_input, *in_i});
       new_blend->SetBlendMode(blend_mode);
-      blend_input = FilterInput::Make(new_blend);
+      if (in_i < inputs.end() - 1) {
+        blend_input = FilterInput::Make(new_blend);
+      }
     }
     // new_blend will always be assigned because inputs.size() >= 2.
     return new_blend;
@@ -104,7 +106,7 @@ bool FilterContents::Render(const ContentContext& renderer,
 
   // Run the filter.
 
-  auto maybe_snapshot = RenderToTexture(renderer, entity);
+  auto maybe_snapshot = RenderToSnapshot(renderer, entity);
   if (!maybe_snapshot.has_value()) {
     return false;
   }
@@ -147,7 +149,7 @@ std::optional<Rect> FilterContents::GetCoverage(const Entity& entity) const {
   return result;
 }
 
-std::optional<Snapshot> FilterContents::RenderToTexture(
+std::optional<Snapshot> FilterContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity) const {
   auto bounds = GetCoverage(entity);
@@ -166,7 +168,8 @@ std::optional<Snapshot> FilterContents::RenderToTexture(
     return std::nullopt;
   }
 
-  return Snapshot{.texture = texture, .position = bounds->origin};
+  return Snapshot{.texture = texture,
+                  .transform = Matrix::MakeTranslation(bounds->origin)};
 }
 
 }  // namespace impeller

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -116,7 +116,7 @@ class FilterContents : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
-  virtual std::optional<Snapshot> RenderToTexture(
+  virtual std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity) const override;
 

--- a/entity/contents/filters/filter_input.h
+++ b/entity/contents/filters/filter_input.h
@@ -50,8 +50,10 @@ class FilterInput final {
  private:
   FilterInput(Variant input);
 
-  std::optional<Snapshot> RenderToTexture(const ContentContext& renderer,
-                                          const Entity& entity) const;
+  std::optional<Snapshot> MakeSnapshot(const ContentContext& renderer,
+                                       const Entity& entity) const;
+
+  std::optional<Snapshot> MakeSnapshotForTexture(const Entity& entity) const;
 
   Variant input_;
   mutable std::optional<Snapshot> snapshot_;

--- a/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -35,7 +35,7 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
                     const ContentContext& renderer,
                     const Entity& entity,
                     RenderPass& pass,
-                    const Rect& bounds) const override;
+                    const Rect& coverage) const override;
   Sigma blur_sigma_;
   Vector2 blur_direction_;
   BlurStyle blur_style_ = BlurStyle::kNormal;

--- a/entity/contents/snapshot.h
+++ b/entity/contents/snapshot.h
@@ -21,16 +21,19 @@ class Entity;
 /// Represents a texture and its intended draw position.
 struct Snapshot {
   std::shared_ptr<Texture> texture;
-  /// The offset from the origin where this texture is intended to be
-  /// rendered.
-  Vector2 position;
+  /// The transform that should be applied to this texture for rendering.
+  Matrix transform;
 
-  /// Transform a texture by the given `entity`'s transformation matrix to a new
-  /// texture.
-  static std::optional<Snapshot> FromTransformedTexture(
-      const ContentContext& renderer,
-      const Entity& entity,
-      std::shared_ptr<Texture> texture);
+  std::optional<Rect> GetCoverage() const;
+
+  /// @brief  Get the transform that converts screen space coordinates to the UV
+  ///         space of this snapshot.
+  std::optional<Matrix> GetUVTransform() const;
+
+  /// @brief  Map a coverage rect to this filter input's UV space.
+  ///         Result order: Top left, top right, bottom left, bottom right.
+  std::optional<std::array<Point, 4>> GetCoverageUVs(
+      const Rect& coverage) const;
 };
 
 }  // namespace impeller

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -733,8 +733,9 @@ TEST_F(EntityTest, GaussianBlurFilter) {
     }
     ImGui::End();
 
-    auto blend = FilterContents::MakeBlend(
-        Entity::BlendMode::kPlus, FilterInput::Make({boston, bridge, bridge}));
+    auto blend =
+        FilterContents::MakeBlend(Entity::BlendMode::kScreen,
+                                  FilterInput::Make({boston, bridge, kalimba}));
 
     auto blur = FilterContents::MakeGaussianBlur(
         FilterInput::Make(blend), FilterContents::Sigma{blur_amount[0]},
@@ -745,7 +746,7 @@ TEST_F(EntityTest, GaussianBlurFilter) {
     auto rect = Rect(-Point(input_size) / 2, Size(input_size));
     auto ctm = Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *
                Matrix::MakeRotationZ(Radians(rotation)) *
-               Matrix::MakeScale(Vector3(scale[0], scale[1])) *
+               Matrix::MakeScale(Vector2(scale[0], scale[1])) *
                Matrix::MakeSkew(skew[0], skew[1]);
 
     auto target_contents = blur;

--- a/entity/shaders/texture_blend_screen.vert
+++ b/entity/shaders/texture_blend_screen.vert
@@ -4,20 +4,18 @@
 
 uniform FrameInfo {
   mat4 mvp;
-  mat4 dst_uv_transform;
-  mat4 src_uv_transform;
-} frame_info;
+}
+frame_info;
 
 in vec2 vertices;
-in vec2 texture_coords;
+in vec2 dst_texture_coords;
+in vec2 src_texture_coords;
 
 out vec2 v_dst_texture_coords;
 out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  v_dst_texture_coords =
-      (frame_info.dst_uv_transform * vec4(texture_coords, 1.0, 1.0)).xy;
-  v_src_texture_coords =
-      (frame_info.src_uv_transform * vec4(texture_coords, 1.0, 1.0)).xy;
+  v_dst_texture_coords = dst_texture_coords;
+  v_src_texture_coords = src_texture_coords;
 }

--- a/geometry/geometry_unittests.cc
+++ b/geometry/geometry_unittests.cc
@@ -57,6 +57,19 @@ TEST(GeometryTest, InvertMultMatrix) {
   }
 }
 
+TEST(GeometryTest, MatrixBasis) {
+  auto matrix = Matrix{1,  2,  3,  4,   //
+                       5,  6,  7,  8,   //
+                       9,  10, 11, 12,  //
+                       13, 14, 15, 16};
+  auto basis = matrix.Basis();
+  auto expect = Matrix{1, 2,  3,  0,  //
+                       5, 6,  7,  0,  //
+                       9, 10, 11, 0,  //
+                       0, 0,  0,  1};
+  ASSERT_MATRIX_NEAR(basis, expect);
+}
+
 TEST(GeometryTest, MutliplicationMatrix) {
   auto rotation = Matrix::MakeRotationZ(Radians{M_PI_4});
   auto invert = rotation.Invert();
@@ -860,6 +873,15 @@ TEST(GeometryTest, RectGetPoints) {
   ASSERT_POINT_NEAR(points[1], Point(400, 200));
   ASSERT_POINT_NEAR(points[2], Point(100, 600));
   ASSERT_POINT_NEAR(points[3], Point(400, 600));
+}
+
+TEST(GeometryTest, RectGetTransformedPoints) {
+  Rect r(100, 200, 300, 400);
+  auto points = r.GetTransformedPoints(Matrix::MakeTranslation({10, 20}));
+  ASSERT_POINT_NEAR(points[0], Point(110, 220));
+  ASSERT_POINT_NEAR(points[1], Point(410, 220));
+  ASSERT_POINT_NEAR(points[2], Point(110, 620));
+  ASSERT_POINT_NEAR(points[3], Point(410, 620));
 }
 
 TEST(GeometryTest, RectMakePointBounds) {

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -165,6 +165,17 @@ struct Matrix {
     // clang-format on
   }
 
+  constexpr Matrix Basis() const {
+    // clang-format off
+    return Matrix(
+      m[0], m[1], m[2],  0.0,
+      m[4], m[5], m[6],  0.0,
+      m[8], m[9], m[10], 0.0,
+      0.0,  0.0,  0.0,   1.0
+    );
+    // clang-format on
+  }
+
   constexpr Matrix Translate(const Vector3& t) const {
     // clang-format off
     return Matrix(m[0], m[1], m[2], m[3],

--- a/geometry/rect.h
+++ b/geometry/rect.h
@@ -139,21 +139,24 @@ struct TRect {
   }
 
   constexpr std::array<TPoint<T>, 4> GetPoints() const {
-    const auto left = std::min(origin.x, origin.x + size.width);
-    const auto top = std::min(origin.y, origin.y + size.height);
-    const auto right = std::max(origin.x, origin.x + size.width);
-    const auto bottom = std::max(origin.y, origin.y + size.height);
+    auto [left, top, right, bottom] = GetLTRB();
     return {TPoint(left, top), TPoint(right, top), TPoint(left, bottom),
             TPoint(right, bottom)};
+  }
+
+  constexpr std::array<TPoint<T>, 4> GetTransformedPoints(
+      const Matrix& transform) const {
+    auto points = GetPoints();
+    for (uint i = 0; i < points.size(); i++) {
+      points[i] = transform * points[i];
+    }
+    return points;
   }
 
   /// @brief  Creates a new bounding box that contains this transformed
   ///         rectangle.
   constexpr TRect TransformBounds(const Matrix& transform) const {
-    auto points = GetPoints();
-    for (uint i = 0; i < points.size(); i++) {
-      points[i] = transform * points[i];
-    }
+    auto points = GetTransformedPoints(transform);
     return TRect::MakePointBounds({points.begin(), points.end()}).value();
   }
 


### PR DESCRIPTION
Replace the `Snapshot` position (which held the position offset of the texture) with a transformation matrix, enabling raw texture `FilterInput`s to be consumed by the graph without pre-passes. The transform is respected equally for any input variant (`Contents` or `Texture`). This also allows for optimizing some less common situations. For example, [MatrixTransform](https://api.skia.org/classSkImageFilters.html#a81f98126fe53bc0bec517d356e805057) filters could just return the same snapshot (sampling mode permitting) except with a multiplied input texture.

Most of the changes here are to make the existing filters respect the transform:
* For basic blends, each input is drawn using a separate draw call, and so the transform is just applied to the geometry.
* For advanced blends and the Gaussian blur, the geometry remains unaffected. Instead, input UVs are computed by transforming the filter's screen space coverage to each input's UV space.