### PR TITLE
Adds --sksl target to impellerc

### DIFF
--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -31,12 +31,17 @@ class Compiler {
     kUnknown,
     kMacOS,
     kIPhoneOS,
+    kFlutterSPIRV,
   };
 
   static SourceType SourceTypeFromFileName(const std::string& file_name);
 
   static std::string EntryPointFromSourceName(const std::string& file_name,
                                               SourceType type);
+
+  static bool TargetPlatformNeedsMSL(TargetPlatform platform);
+
+  static bool TargetPlatformNeedsReflection(TargetPlatform platform);
 
   struct SourceOptions {
     SourceType type = SourceType::kUnknown;

--- a/compiler/compiler_unittests.cc
+++ b/compiler/compiler_unittests.cc
@@ -23,14 +23,15 @@ class CompilerTest : public ::testing::Test {
 
   ~CompilerTest() = default;
 
-  bool CanCompileFixture(const char* fixture_name) const {
+  bool CanCompileFixture(const char* fixture_name,
+                         Compiler::TargetPlatform target_platform) const {
     auto fixture = flutter::testing::OpenFixtureAsMapping(fixture_name);
     if (!fixture->GetMapping()) {
       VALIDATION_LOG << "Could not find shader in fixtures: " << fixture_name;
       return false;
     }
     Compiler::SourceOptions compiler_options(fixture_name);
-    compiler_options.target_platform = Compiler::TargetPlatform::kMacOS;
+    compiler_options.target_platform = target_platform;
     compiler_options.working_directory = std::make_shared<fml::UniqueFD>(
         flutter::testing::OpenFixturesDirectory());
     Reflector::Options reflector_options;
@@ -60,7 +61,13 @@ TEST_F(CompilerTest, ShaderKindMatchingIsSuccessful) {
 }
 
 TEST_F(CompilerTest, CanCompileSample) {
-  ASSERT_TRUE(CanCompileFixture("sample.vert"));
+  ASSERT_TRUE(CanCompileFixture(
+      "sample.vert", Compiler::TargetPlatform::kMacOS));
+}
+
+TEST_F(CompilerTest, CanTargetFlutterSPIRV) {
+  ASSERT_TRUE(CanCompileFixture(
+    "test_texture.frag", Compiler::TargetPlatform::kFlutterSPIRV));
 }
 
 }  // namespace testing

--- a/compiler/switches.cc
+++ b/compiler/switches.cc
@@ -15,6 +15,7 @@ namespace compiler {
 static const std::map<std::string, Compiler::TargetPlatform> kKnownPlatforms = {
     {"macos", Compiler::TargetPlatform::kMacOS},
     {"ios", Compiler::TargetPlatform::kIPhoneOS},
+    {"flutter-spirv", Compiler::TargetPlatform::kFlutterSPIRV},
 };
 
 void Switches::PrintHelp(std::ostream& stream) {
@@ -112,7 +113,7 @@ bool Switches::AreValid(std::ostream& explain) const {
     valid = false;
   }
 
-  if (metal_file_name.empty()) {
+  if (metal_file_name.empty() && Compiler::TargetPlatformNeedsMSL(target_platform)) {
     explain << "Metal file name was empty." << std::endl;
     valid = false;
   }

--- a/fixtures/BUILD.gn
+++ b/fixtures/BUILD.gn
@@ -21,13 +21,14 @@ impeller_shaders("shader_fixtures") {
 
 test_fixtures("file_fixtures") {
   fixtures = [
-    "sample.vert",
-    "types.h",
     "airplane.jpg",
     "bay_bridge.jpg",
     "boston.jpg",
     "embarcadero.jpg",
     "kalimba.jpg",
+    "sample.vert",
+    "types.h",
+    "test_texture.frag",
     "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf",
     "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf",
     "//flutter/third_party/txt/third_party/fonts/HomemadeApple.ttf",


### PR DESCRIPTION
The goal of this PR is to add support to impellerc for compiling glsl fragment shaders to SPIR-V such that they'll be accepted by the SPIR-V to SkSL transpiler in the Engine.

This will help migrate the hardcoded SPIR-V bytecode out of the framework at:

https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/ink_sparkle.dart#L690

and into a file asset: https://github.com/flutter/flutter/issues/99783.

Using impellerc for this rather than another tool will make it easier to generate the platform specific shaders to feed to the `FragmentProgram` API when Impeller is enabled because the Engine will only need to vend one additional binary. The next step after this PR is getting impellerc building on Linux and then Windows.