### PR TITLE
Border mask blur

### DIFF
--- a/entity/BUILD.gn
+++ b/entity/BUILD.gn
@@ -20,6 +20,8 @@ impeller_shaders("entity_shaders") {
     "shaders/texture_blend_screen.vert",
     "shaders/gaussian_blur.frag",
     "shaders/gaussian_blur.vert",
+    "shaders/border_mask_blur.frag",
+    "shaders/border_mask_blur.vert",
     "shaders/texture_fill.frag",
     "shaders/texture_fill.vert",
     "shaders/glyph_atlas.frag",
@@ -45,6 +47,8 @@ impeller_component("entity") {
     "contents/filters/filter_input.h",
     "contents/filters/gaussian_blur_filter_contents.cc",
     "contents/filters/gaussian_blur_filter_contents.h",
+    "contents/filters/border_mask_blur_filter_contents.cc",
+    "contents/filters/border_mask_blur_filter_contents.h",
     "contents/linear_gradient_contents.cc",
     "contents/linear_gradient_contents.h",
     "contents/snapshot.cc",
@@ -80,6 +84,7 @@ impeller_component("entity_unittests") {
   testonly = true
 
   sources = [
+    "../geometry/geometry_unittests.h",
     "entity_playground.cc",
     "entity_playground.h",
     "entity_unittests.cc",

--- a/entity/BUILD.gn
+++ b/entity/BUILD.gn
@@ -84,7 +84,6 @@ impeller_component("entity_unittests") {
   testonly = true
 
   sources = [
-    "../geometry/geometry_unittests.h",
     "entity_playground.cc",
     "entity_playground.h",
     "entity_unittests.cc",

--- a/entity/contents/content_context.cc
+++ b/entity/contents/content_context.cc
@@ -29,6 +29,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
   texture_pipelines_[{}] = std::make_unique<TexturePipeline>(*context_);
   gaussian_blur_pipelines_[{}] =
       std::make_unique<GaussianBlurPipeline>(*context_);
+  border_mask_blur_pipelines_[{}] =
+      std::make_unique<BorderMaskBlurPipeline>(*context_);
   solid_stroke_pipelines_[{}] =
       std::make_unique<SolidStrokePipeline>(*context_);
   glyph_atlas_pipelines_[{}] = std::make_unique<GlyphAtlasPipeline>(*context_);

--- a/entity/contents/content_context.h
+++ b/entity/contents/content_context.h
@@ -11,6 +11,8 @@
 #include "flutter/fml/macros.h"
 #include "fml/logging.h"
 #include "impeller/base/validation.h"
+#include "impeller/entity/border_mask_blur.frag.h"
+#include "impeller/entity/border_mask_blur.vert.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/gaussian_blur.frag.h"
 #include "impeller/entity/gaussian_blur.vert.h"
@@ -44,6 +46,8 @@ using TexturePipeline =
     PipelineT<TextureFillVertexShader, TextureFillFragmentShader>;
 using GaussianBlurPipeline =
     PipelineT<GaussianBlurVertexShader, GaussianBlurFragmentShader>;
+using BorderMaskBlurPipeline =
+    PipelineT<BorderMaskBlurVertexShader, BorderMaskBlurFragmentShader>;
 using SolidStrokePipeline =
     PipelineT<SolidStrokeVertexShader, SolidStrokeFragmentShader>;
 using GlyphAtlasPipeline =
@@ -114,6 +118,11 @@ class ContentContext {
     return GetPipeline(gaussian_blur_pipelines_, opts);
   }
 
+  std::shared_ptr<Pipeline> GetBorderMaskBlurPipeline(
+      ContentContextOptions opts) const {
+    return GetPipeline(border_mask_blur_pipelines_, opts);
+  }
+
   std::shared_ptr<Pipeline> GetSolidStrokePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(solid_stroke_pipelines_, opts);
@@ -156,6 +165,7 @@ class ContentContext {
   mutable Variants<TextureBlendScreenPipeline> texture_blend_screen_pipelines_;
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<GaussianBlurPipeline> gaussian_blur_pipelines_;
+  mutable Variants<BorderMaskBlurPipeline> border_mask_blur_pipelines_;
   mutable Variants<SolidStrokePipeline> solid_stroke_pipelines_;
   mutable Variants<ClipPipeline> clip_pipelines_;
   mutable Variants<GlyphAtlasPipeline> glyph_atlas_pipelines_;

--- a/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -1,0 +1,126 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/filters/border_mask_blur_filter_contents.h"
+#include "impeller/entity/contents/content_context.h"
+
+#include "impeller/entity/contents/contents.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/renderer/sampler_library.h"
+
+namespace impeller {
+
+BorderMaskBlurFilterContents::BorderMaskBlurFilterContents() = default;
+
+BorderMaskBlurFilterContents::~BorderMaskBlurFilterContents() = default;
+
+void BorderMaskBlurFilterContents::SetSigma(Sigma sigma_x, Sigma sigma_y) {
+  sigma_x_ = sigma_x;
+  sigma_y_ = sigma_y;
+}
+
+void BorderMaskBlurFilterContents::SetBlurStyle(BlurStyle blur_style) {
+  blur_style_ = blur_style;
+
+  switch (blur_style) {
+    case FilterContents::BlurStyle::kNormal:
+      src_color_factor_ = false;
+      inner_blur_factor_ = true;
+      outer_blur_factor_ = true;
+      break;
+    case FilterContents::BlurStyle::kSolid:
+      src_color_factor_ = true;
+      inner_blur_factor_ = false;
+      outer_blur_factor_ = true;
+      break;
+    case FilterContents::BlurStyle::kOuter:
+      src_color_factor_ = false;
+      inner_blur_factor_ = false;
+      outer_blur_factor_ = true;
+      break;
+    case FilterContents::BlurStyle::kInner:
+      src_color_factor_ = false;
+      inner_blur_factor_ = true;
+      outer_blur_factor_ = false;
+      break;
+  }
+}
+
+bool BorderMaskBlurFilterContents::RenderFilter(
+    const FilterInput::Vector& inputs,
+    const ContentContext& renderer,
+    const Entity& entity,
+    RenderPass& pass,
+    const Rect& coverage) const {
+  if (inputs.empty()) {
+    return true;
+  }
+
+  using VS = BorderMaskBlurPipeline::VertexShader;
+  using FS = BorderMaskBlurPipeline::FragmentShader;
+
+  auto& host_buffer = pass.GetTransientsBuffer();
+
+  auto input_snapshot = inputs[0]->GetSnapshot(renderer, entity);
+  if (!input_snapshot.has_value()) {
+    return true;
+  }
+  auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
+  if (!maybe_input_uvs.has_value()) {
+    return true;
+  }
+  auto input_uvs = maybe_input_uvs.value();
+
+  VertexBufferBuilder<VS::PerVertexData> vtx_builder;
+  vtx_builder.AddVertices({
+      {Point(0, 0), input_uvs[0]},
+      {Point(1, 0), input_uvs[1]},
+      {Point(1, 1), input_uvs[3]},
+      {Point(0, 0), input_uvs[0]},
+      {Point(1, 1), input_uvs[3]},
+      {Point(0, 1), input_uvs[2]},
+  });
+  auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
+
+  Command cmd;
+  cmd.label = "Border Mask Blur Filter";
+  auto options = OptionsFromPass(pass);
+  options.blend_mode = Entity::BlendMode::kSource;
+  cmd.pipeline = renderer.GetBorderMaskBlurPipeline(options);
+  cmd.BindVertices(vtx_buffer);
+
+  VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
+  frame_info.sigma_uv = Vector2(sigma_x_.sigma, sigma_y_.sigma) /
+                        input_snapshot->texture->GetSize();
+  frame_info.src_factor = src_color_factor_;
+  frame_info.inner_blur_factor = inner_blur_factor_;
+  frame_info.outer_blur_factor = outer_blur_factor_;
+  auto uniform_view = host_buffer.EmplaceUniform(frame_info);
+  VS::BindFrameInfo(cmd, uniform_view);
+
+  auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+  FS::BindTextureSampler(cmd, input_snapshot->texture, sampler);
+
+  return pass.AddCommand(std::move(cmd));
+}
+
+std::optional<Rect> BorderMaskBlurFilterContents::GetCoverage(
+    const Entity& entity) const {
+  auto coverage = FilterContents::GetCoverage(entity);
+  if (!coverage.has_value()) {
+    return std::nullopt;
+  }
+
+  auto transformed_blur_vector =
+      entity.GetTransformation()
+          .TransformDirection(
+              Vector2(Radius{sigma_x_}.radius, Radius{sigma_y_}.radius))
+          .Abs();
+  auto extent = coverage->size + transformed_blur_vector * 2;
+  return Rect(coverage->origin - transformed_blur_vector,
+              Size(extent.x, extent.y));
+}
+
+}  // namespace impeller

--- a/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -92,7 +92,9 @@ bool BorderMaskBlurFilterContents::RenderFilter(
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-  frame_info.sigma_uv = Vector2(sigma_x_.sigma, sigma_y_.sigma) /
+  auto scale = entity.GetTransformation().GetScale();
+  frame_info.sigma_uv = Vector2(scale.x, scale.y) *
+                        Vector2(sigma_x_.sigma, sigma_y_.sigma).Abs() /
                         input_snapshot->texture->GetSize();
   frame_info.src_factor = src_color_factor_;
   frame_info.inner_blur_factor = inner_blur_factor_;

--- a/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -115,6 +115,9 @@ std::optional<Rect> BorderMaskBlurFilterContents::GetCoverage(
     return std::nullopt;
   }
 
+  // Technically this works with all of our current filters, but this should be
+  // using the input[0] transform, not the entity transform!
+  // See: https://github.com/flutter/impeller/pull/130#issuecomment-1098892423
   auto transformed_blur_vector =
       entity.GetTransformation()
           .TransformDirection(

--- a/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -11,19 +11,15 @@
 
 namespace impeller {
 
-class DirectionalGaussianBlurFilterContents final : public FilterContents {
+class BorderMaskBlurFilterContents final : public FilterContents {
  public:
-  DirectionalGaussianBlurFilterContents();
+  BorderMaskBlurFilterContents();
 
-  ~DirectionalGaussianBlurFilterContents() override;
+  ~BorderMaskBlurFilterContents() override;
 
-  void SetSigma(Sigma sigma);
-
-  void SetDirection(Vector2 direction);
+  void SetSigma(Sigma sigma_x, Sigma sigma_y);
 
   void SetBlurStyle(BlurStyle blur_style);
-
-  void SetSourceOverride(FilterInput::Ref alpha_mask);
 
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
@@ -35,15 +31,14 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
                     const Entity& entity,
                     RenderPass& pass,
                     const Rect& coverage) const override;
-  Sigma blur_sigma_;
-  Vector2 blur_direction_;
+  Sigma sigma_x_;
+  Sigma sigma_y_;
   BlurStyle blur_style_ = BlurStyle::kNormal;
   bool src_color_factor_ = false;
   bool inner_blur_factor_ = true;
   bool outer_blur_factor_ = true;
-  FilterInput::Ref source_override_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DirectionalGaussianBlurFilterContents);
+  FML_DISALLOW_COPY_AND_ASSIGN(BorderMaskBlurFilterContents);
 };
 
 }  // namespace impeller

--- a/entity/contents/filters/filter_contents.cc
+++ b/entity/contents/filters/filter_contents.cc
@@ -15,6 +15,7 @@
 #include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/filters/blend_filter_contents.h"
+#include "impeller/entity/contents/filters/border_mask_blur_filter_contents.h"
 #include "impeller/entity/contents/filters/filter_input.h"
 #include "impeller/entity/contents/filters/gaussian_blur_filter_contents.h"
 #include "impeller/entity/contents/texture_contents.h"
@@ -86,6 +87,18 @@ std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
   auto y_blur = MakeDirectionalGaussianBlur(FilterInput::Make(x_blur), sigma_y,
                                             Point(0, 1), blur_style, input);
   return y_blur;
+}
+
+std::shared_ptr<FilterContents> FilterContents::MakeBorderMaskBlur(
+    FilterInput::Ref input,
+    Sigma sigma_x,
+    Sigma sigma_y,
+    BlurStyle blur_style) {
+  auto filter = std::make_shared<BorderMaskBlurFilterContents>();
+  filter->SetInputs({input});
+  filter->SetSigma(sigma_x, sigma_y);
+  filter->SetBlurStyle(blur_style);
+  return filter;
 }
 
 FilterContents::FilterContents() = default;

--- a/entity/contents/filters/filter_contents.h
+++ b/entity/contents/filters/filter_contents.h
@@ -96,6 +96,12 @@ class FilterContents : public Contents {
       Sigma sigma_y,
       BlurStyle blur_style = BlurStyle::kNormal);
 
+  static std::shared_ptr<FilterContents> MakeBorderMaskBlur(
+      FilterInput::Ref input,
+      Sigma sigma_x,
+      Sigma sigma_y,
+      BlurStyle blur_style = BlurStyle::kNormal);
+
   FilterContents();
 
   ~FilterContents() override;

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -698,16 +698,18 @@ TEST_F(EntityTest, GaussianBlurFilter) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     if (first_frame) {
       first_frame = false;
-      ImGui::SetNextWindowSize({500, 220});
-      ImGui::SetNextWindowPos({300, 550});
+      ImGui::SetNextWindowSize({500, 250});
+      ImGui::SetNextWindowPos({300, 500});
     }
 
+    const char* blur_type_names[] = {"Image blur", "Mask blur"};
     const char* blur_style_names[] = {"Normal", "Solid", "Outer", "Inner"};
     const FilterContents::BlurStyle blur_styles[] = {
         FilterContents::BlurStyle::kNormal, FilterContents::BlurStyle::kSolid,
         FilterContents::BlurStyle::kOuter, FilterContents::BlurStyle::kInner};
 
     // UI state.
+    static int selected_blur_type = 0;
     static float blur_amount[2] = {20, 20};
     static int selected_blur_style = 0;
     static Color cover_color(1, 0, 0, 0.2);
@@ -719,6 +721,8 @@ TEST_F(EntityTest, GaussianBlurFilter) {
 
     ImGui::Begin("Controls");
     {
+      ImGui::Combo("Blur type", &selected_blur_type, blur_type_names,
+                   sizeof(blur_type_names) / sizeof(char*));
       ImGui::SliderFloat2("Blur", &blur_amount[0], 0, 200);
       ImGui::Combo("Blur style", &selected_blur_style, blur_style_names,
                    sizeof(blur_style_names) / sizeof(char*));
@@ -743,8 +747,9 @@ TEST_F(EntityTest, GaussianBlurFilter) {
         blur_styles[selected_blur_style]);
 
     auto mask_blur = FilterContents::MakeBorderMaskBlur(
-        FilterInput::Make(blend), FilterContents::Sigma{blur_amount[0]},
-        FilterContents::Sigma{blur_amount[1]});
+        FilterInput::Make(boston), FilterContents::Sigma{blur_amount[0]},
+        FilterContents::Sigma{blur_amount[1]},
+        blur_styles[selected_blur_style]);
 
     ISize input_size = boston->GetSize();
     auto rect = Rect(-Point(input_size) / 2, Size(input_size));
@@ -753,7 +758,7 @@ TEST_F(EntityTest, GaussianBlurFilter) {
                Matrix::MakeScale(Vector2(scale[0], scale[1])) *
                Matrix::MakeSkew(skew[0], skew[1]);
 
-    auto target_contents = mask_blur;
+    auto target_contents = selected_blur_type == 0 ? blur : mask_blur;
 
     Entity entity;
     entity.SetPath(PathBuilder{}.AddRect(rect).TakePath());

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -742,6 +742,10 @@ TEST_F(EntityTest, GaussianBlurFilter) {
         FilterContents::Sigma{blur_amount[1]},
         blur_styles[selected_blur_style]);
 
+    auto mask_blur = FilterContents::MakeBorderMaskBlur(
+        FilterInput::Make(blend), FilterContents::Sigma{blur_amount[0]},
+        FilterContents::Sigma{blur_amount[1]});
+
     ISize input_size = boston->GetSize();
     auto rect = Rect(-Point(input_size) / 2, Size(input_size));
     auto ctm = Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *
@@ -749,7 +753,7 @@ TEST_F(EntityTest, GaussianBlurFilter) {
                Matrix::MakeScale(Vector2(scale[0], scale[1])) *
                Matrix::MakeSkew(skew[0], skew[1]);
 
-    auto target_contents = blur;
+    auto target_contents = mask_blur;
 
     Entity entity;
     entity.SetPath(PathBuilder{}.AddRect(rect).TakePath());

--- a/entity/shaders/border_mask_blur.frag
+++ b/entity/shaders/border_mask_blur.frag
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Constant time mask blur for image borders.
+//
+// This mask blur extends the geometry of the source image (with clamp border
+// sampling) and applies a Gaussian blur to the alpha mask at the edges.
+//
+// The blur itself works by mapping the Gaussian distribution's indefinite
+// integral (using an erf approximation) to the 4 edges of the UV rectangle and
+// multiplying them.
+
+uniform sampler2D texture_sampler;
+
+in vec2 v_texture_coords;
+in vec2 v_sigma_uv;
+in float v_src_factor;
+in float v_inner_blur_factor;
+in float v_outer_blur_factor;
+
+out vec4 frag_color;
+
+// Abramowitz and Stegun erf approximation.
+float erf(float x) {
+  float a = abs(x);
+  // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
+  float b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
+  return sign(x) * (1 - 1 / (b * b * b * b));
+}
+
+// Normalized indefinite integral of the Gaussian function.
+float GaussianIntegral(float x, float sigma) {
+  return 0.5 + 0.5 * erf(x / sigma);
+}
+
+float BoxBlurMask(vec2 uv) {
+  // LTRB
+  return GaussianIntegral(uv.x, v_sigma_uv.x) *      //
+         GaussianIntegral(uv.y, v_sigma_uv.y) *      //
+         GaussianIntegral(1 - uv.x, v_sigma_uv.x) *  //
+         GaussianIntegral(1 - uv.y, v_sigma_uv.y);
+}
+
+void main() {
+  vec4 image_color = texture(texture_sampler, v_texture_coords);
+  float blur_factor = BoxBlurMask(v_texture_coords);
+
+  float within_bounds =
+      float(v_texture_coords.x >= 0 && v_texture_coords.y >= 0 &&
+            v_texture_coords.x < 1 && v_texture_coords.y < 1);
+  float inner_mask_factor =
+      (v_inner_blur_factor * blur_factor + v_src_factor) * within_bounds;
+  float outer_mask_factor =
+      v_outer_blur_factor * blur_factor * (1 - within_bounds);
+
+  float alpha_mask = inner_mask_factor + outer_mask_factor;
+  frag_color = vec4(image_color.rgb, image_color.a * alpha_mask);
+}

--- a/entity/shaders/border_mask_blur.frag
+++ b/entity/shaders/border_mask_blur.frag
@@ -29,7 +29,7 @@ float erf(float x) {
   return sign(x) * (1 - 1 / (b * b * b * b));
 }
 
-// Normalized indefinite integral of the Gaussian function.
+// Indefinite integral of the Gaussian function (with constant range 0->1).
 float GaussianIntegral(float x, float sigma) {
   return 0.5 + 0.5 * erf(x / sigma);
 }
@@ -49,11 +49,10 @@ void main() {
   float within_bounds =
       float(v_texture_coords.x >= 0 && v_texture_coords.y >= 0 &&
             v_texture_coords.x < 1 && v_texture_coords.y < 1);
-  float inner_mask_factor =
+  float inner_factor =
       (v_inner_blur_factor * blur_factor + v_src_factor) * within_bounds;
-  float outer_mask_factor =
-      v_outer_blur_factor * blur_factor * (1 - within_bounds);
+  float outer_factor = v_outer_blur_factor * blur_factor * (1 - within_bounds);
 
-  float alpha_mask = inner_mask_factor + outer_mask_factor;
-  frag_color = image_color * alpha_mask;
+  float mask_factor = inner_factor + outer_factor;
+  frag_color = image_color * mask_factor;
 }

--- a/entity/shaders/border_mask_blur.frag
+++ b/entity/shaders/border_mask_blur.frag
@@ -55,5 +55,5 @@ void main() {
       v_outer_blur_factor * blur_factor * (1 - within_bounds);
 
   float alpha_mask = inner_mask_factor + outer_mask_factor;
-  frag_color = vec4(image_color.rgb, image_color.a * alpha_mask);
+  frag_color = image_color * alpha_mask;
 }

--- a/entity/shaders/border_mask_blur.frag
+++ b/entity/shaders/border_mask_blur.frag
@@ -29,9 +29,11 @@ float erf(float x) {
   return sign(x) * (1 - 1 / (b * b * b * b));
 }
 
+const float kHalfSqrtTwo = 0.70710678118;
+
 // Indefinite integral of the Gaussian function (with constant range 0->1).
 float GaussianIntegral(float x, float sigma) {
-  return 0.5 + 0.5 * erf(x / sigma);
+  return 0.5 + 0.5 * erf(x * (kHalfSqrtTwo / sigma));
 }
 
 float BoxBlurMask(vec2 uv) {

--- a/entity/shaders/border_mask_blur.vert
+++ b/entity/shaders/border_mask_blur.vert
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FrameInfo {
+  mat4 mvp;
+
+  vec2 sigma_uv;
+
+  float src_factor;
+  float inner_blur_factor;
+  float outer_blur_factor;
+}
+frame_info;
+
+in vec2 vertices;
+in vec2 texture_coords;
+
+out vec2 v_texture_coords;
+out vec2 v_sigma_uv;
+out float v_src_factor;
+out float v_inner_blur_factor;
+out float v_outer_blur_factor;
+
+void main() {
+  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
+  v_texture_coords = texture_coords;
+  v_sigma_uv = frame_info.sigma_uv;
+  v_src_factor = frame_info.src_factor;
+  v_inner_blur_factor = frame_info.inner_blur_factor;
+  v_outer_blur_factor = frame_info.outer_blur_factor;
+}

--- a/geometry/matrix.h
+++ b/geometry/matrix.h
@@ -236,6 +236,12 @@ struct Matrix {
 
   Scalar GetMaxBasisLength() const;
 
+  constexpr Vector3 GetScale() const {
+    return Vector3(Vector3(m[0], m[1], m[2]).Length(),
+                   Vector3(m[4], m[5], m[6]).Length(),
+                   Vector3(m[8], m[9], m[10]).Length());
+  }
+
   constexpr bool IsAffine() const {
     return (m[2] == 0 && m[3] == 0 && m[6] == 0 && m[7] == 0 && m[8] == 0 &&
             m[9] == 0 && m[10] == 1 && m[11] == 0 && m[14] == 0 && m[15] == 1);


### PR DESCRIPTION
Directly depends on changes in https://github.com/flutter/impeller/pull/130.

Adds a constant time mask blur for image borders.

This mask blur extends the geometry of the source image (with clamp border sampling) and applies a Gaussian blur to the original geometry mask.

The blur itself works by mapping the Gaussian distribution's indefinite integral (with a very close erf approximation) to the 4 edges of the UV rectangle and multiplying them.

https://user-images.githubusercontent.com/919017/163268514-cc9ea43a-0f73-4b00-b10a-dc490cc01a6f.mov

I'm planning a follow-up that allows filters to return snapshots, which will allow filters that don't modify coverage to do filtering into textures of the same size without having to worry about repositioning geometry/expanding contents. This way, we can chain `BorderMaskBlurFilterContents` after things like `BlendFilterContents` or the upcoming `ColorFilterContents` and it'll always extend the border of the original texture correctly. This would also enable filters to just pass through snapshots whenever no computation needs to be done.