### PR TITLE
Move rendering TUs behind own flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -20,38 +20,48 @@ config("impeller_public_config") {
 
 group("impeller") {
   public_deps = [
-    "aiks",
     "archivist",
     "base",
-    "display_list",
-    "entity",
     "geometry",
-    "image",
-    "renderer",
     "tessellator",
-    "typographer",
   ]
+
+  if (impeller_supports_rendering) {
+    deps += [
+      "aiks",
+      "display_list",
+      "entity",
+      "image",
+      "renderer",
+      "typographer",
+    ]
+  }
 }
 
 executable("impeller_unittests") {
   testonly = true
 
   deps = [
-    "aiks:aiks_unittests",
     "archivist:archivist_unittests",
     "base:base_unittests",
     "compiler:compiler_unittests",
-    "display_list:display_list_unittests",
-    "entity:entity_unittests",
     "fixtures",
     "geometry:geometry_unittests",
-    "image:image_unittests",
-    "playground",
-    "renderer:renderer_unittests",
-    "typographer:typographer_unittests",
 
     # FML depends on the Dart VM for tracing and getting the current
     # timepoint.
     "//flutter/runtime:libdart",
   ]
+
+  if (impeller_supports_rendering) {
+    deps += [
+      "aiks:aiks_unittests",
+      "display_list:display_list_unittests",
+      "entity:entity_unittests",
+      "image:image_unittests",
+      "playground",
+      "renderer:renderer_unittests",
+      "typographer:typographer_unittests",
+    ]
+  }
 }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -27,7 +27,7 @@ group("impeller") {
   ]
 
   if (impeller_supports_rendering) {
-    deps += [
+    public_deps += [
       "aiks",
       "display_list",
       "entity",

--- a/tools/impeller.gni
+++ b/tools/impeller.gni
@@ -12,6 +12,9 @@ declare_args() {
   # Whether Impeller is supported on the platform.
   impeller_supports_platform = true
 
+  # Whether Impeller supports rendering on the platform.
+  impeller_supports_rendering = is_mac || is_ios
+
   # Whether Impeller shaders are supported on the platform.
   impeller_shaders_supports_platform = is_mac || is_ios
 }


### PR DESCRIPTION
Fixes build issues seen in https://github.com/flutter/engine/pull/32658

Will require one change when rolling into the engine to guard header includes behind this new flag instead of the more generic one.