### PR TITLE
Fix enum typedef for older mac SDKs

### DIFF
--- a/renderer/backend/metal/command_buffer_mtl.mm
+++ b/renderer/backend/metal/command_buffer_mtl.mm
@@ -55,7 +55,7 @@ static CommandBuffer::Status ToCommitResult(MTLCommandBufferStatus status) {
 
 // TODO(dnfield): remove this declaration when we no longer need to build on
 // machines with lower SDK versions than 11.0.s
-#if !defined(MAC_OS_X_VERSION_11_0) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_11_0
+#if !defined(MAC_OS_VERSION_11_0) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_11_0
 typedef NS_ENUM(NSInteger, MTLCommandEncoderErrorState) {
   MTLCommandEncoderErrorStateUnknown = 0,
   MTLCommandEncoderErrorStateCompleted = 1,

--- a/renderer/backend/metal/command_buffer_mtl.mm
+++ b/renderer/backend/metal/command_buffer_mtl.mm
@@ -56,7 +56,7 @@ static CommandBuffer::Status ToCommitResult(MTLCommandBufferStatus status) {
 // TODO(dnfield): remove this declaration when we no longer need to build on
 // machines with lower SDK versions than 11.0.s
 #if !defined(MAC_OS_X_VERSION_11_0) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_11_0
-typedef enum MTLCommandEncoderErrorState : NSInteger {
+typedef NS_ENUM(NSInteger, MTLCommandEncoderErrorState) {
   MTLCommandEncoderErrorStateUnknown = 0,
   MTLCommandEncoderErrorStateCompleted = 1,
   MTLCommandEncoderErrorStateAffected = 2,

--- a/renderer/backend/metal/command_buffer_mtl.mm
+++ b/renderer/backend/metal/command_buffer_mtl.mm
@@ -63,7 +63,10 @@ typedef NS_ENUM(NSInteger, MTLCommandEncoderErrorState) {
   MTLCommandEncoderErrorStatePending = 3,
   MTLCommandEncoderErrorStateFaulted = 4,
 } API_AVAILABLE(macos(11.0), ios(14.0));
+#endif
 
+
+#if !defined(MAC_OS_VERSION_12_0) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_12_0
 constexpr int MTLCommandBufferErrorAccessRevoked = 4;
 constexpr int MTLCommandBufferErrorStackOverflow = 12;
 #endif

--- a/renderer/backend/metal/command_buffer_mtl.mm
+++ b/renderer/backend/metal/command_buffer_mtl.mm
@@ -63,6 +63,9 @@ typedef NS_ENUM(NSInteger, MTLCommandEncoderErrorState) {
   MTLCommandEncoderErrorStatePending = 3,
   MTLCommandEncoderErrorStateFaulted = 4,
 } API_AVAILABLE(macos(11.0), ios(14.0));
+
+constexpr int MTLCommandBufferErrorAccessRevoked = 4;
+constexpr int MTLCommandBufferErrorStackOverflow = 12;
 #endif
 
 API_AVAILABLE(ios(14.0), macos(11.0))


### PR DESCRIPTION
I .. I forget how to write ObjC.

I'm going to let CI finish on https://github.com/flutter/engine/pull/32658 (which currently points to my fork) before landing this.