### PR TITLE
Implement mask blur in display list dispatcher

### DIFF
--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -237,6 +237,7 @@ void Canvas::DrawImageRect(std::shared_ptr<Image> image,
   contents->SetTexture(image->GetTexture());
   contents->SetSourceRect(source);
   contents->SetSamplerDescriptor(std::move(sampler));
+
   Entity entity;
   entity.SetPath(PathBuilder{}.AddRect(dest).TakePath());
   entity.SetBlendMode(paint.blend_mode);
@@ -295,7 +296,7 @@ void Canvas::DrawTextFrame(TextFrame text_frame, Point position, Paint paint) {
   entity.SetPath({});
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.WithFilters(std::move(text_contents)));
+  entity.SetContents(paint.WithFilters(std::move(text_contents), true));
 
   GetCurrentPass().AddEntity(std::move(entity));
 }

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -114,7 +114,7 @@ void Canvas::DrawPath(Path path, Paint paint) {
   entity.SetPath(std::move(path));
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.CreateContentsForEntity());
+  entity.SetContents(paint.WithFilters(paint.CreateContentsForEntity()));
 
   GetCurrentPass().AddEntity(std::move(entity));
 }
@@ -237,12 +237,11 @@ void Canvas::DrawImageRect(std::shared_ptr<Image> image,
   contents->SetTexture(image->GetTexture());
   contents->SetSourceRect(source);
   contents->SetSamplerDescriptor(std::move(sampler));
-
   Entity entity;
   entity.SetPath(PathBuilder{}.AddRect(dest).TakePath());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetStencilDepth(GetStencilDepth());
-  entity.SetContents(contents);
+  entity.SetContents(paint.WithFilters(contents, false));
   entity.SetTransformation(GetCurrentTransformation());
 
   GetCurrentPass().AddEntity(std::move(entity));

--- a/aiks/canvas.cc
+++ b/aiks/canvas.cc
@@ -295,7 +295,7 @@ void Canvas::DrawTextFrame(TextFrame text_frame, Point position, Paint paint) {
   entity.SetPath({});
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(std::move(text_contents));
+  entity.SetContents(paint.WithFilters(std::move(text_contents)));
 
   GetCurrentPass().AddEntity(std::move(entity));
 }

--- a/aiks/paint.cc
+++ b/aiks/paint.cc
@@ -33,4 +33,24 @@ std::shared_ptr<Contents> Paint::CreateContentsForEntity() const {
   return nullptr;
 }
 
+std::shared_ptr<Contents> Paint::WithFilters(
+    std::shared_ptr<Contents> input,
+    std::optional<bool> is_solid_color) const {
+  bool is_solid_color_val = is_solid_color.value_or(!contents);
+
+  if (mask_blur.has_value()) {
+    if (is_solid_color_val) {
+      input = FilterContents::MakeGaussianBlur(
+          FilterInput::Make(input), mask_blur->sigma, mask_blur->sigma,
+          mask_blur->blur_style);
+    } else {
+      input = FilterContents::MakeBorderMaskBlur(
+          FilterInput::Make(input), mask_blur->sigma, mask_blur->sigma,
+          mask_blur->blur_style);
+    }
+  }
+
+  return input;
+}
+
 }  // namespace impeller

--- a/aiks/paint.h
+++ b/aiks/paint.h
@@ -8,11 +8,17 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/contents.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
 
 namespace impeller {
+
+struct MaskBlur {
+  FilterContents::BlurStyle blur_style;
+  FilterContents::Sigma sigma;
+};
 
 struct Paint {
   enum class Style {
@@ -27,9 +33,25 @@ struct Paint {
   Scalar stroke_miter = 4.0;
   Style style = Style::kFill;
   Entity::BlendMode blend_mode = Entity::BlendMode::kSourceOver;
+  std::optional<MaskBlur> mask_blur;
   std::shared_ptr<Contents> contents;
 
   std::shared_ptr<Contents> CreateContentsForEntity() const;
+
+  /// @brief      Wrap this paint's configured filters to the given contents.
+  /// @param[in]  input           The contents to wrap with paint's filters.
+  /// @param[in]  is_solid_color  Affects mask blurring behavior. If false, use
+  ///                             the image border for mask blurring. If true,
+  ///                             do a Gaussian blur to achieve the mask
+  ///                             blurring effect for arbitrary paths. If unset,
+  ///                             use the current paint configuration to infer
+  ///                             the result.
+  /// @return     The filter-wrapped contents. If there are no filters that need
+  ///             to be wrapped for the current paint configuration, the
+  ///             original contents is returned.
+  std::shared_ptr<Contents> WithFilters(
+      std::shared_ptr<Contents> input,
+      std::optional<bool> is_solid_color = std::nullopt) const;
 };
 
 }  // namespace impeller

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "display_list/display_list_mask_filter.h"
 #include "gtest/gtest.h"
-#include "include/core/SkBlurTypes.h"
 #include "third_party/imgui/imgui.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkPathBuilder.h"
 
 #include "flutter/display_list/display_list_builder.h"
+#include "flutter/display_list/display_list_mask_filter.h"
 #include "flutter/display_list/types.h"
 #include "flutter/testing/testing.h"
 #include "impeller/display_list/display_list_image_impeller.h"

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "display_list/display_list_mask_filter.h"
 #include "gtest/gtest.h"
+#include "include/core/SkBlurTypes.h"
 #include "third_party/imgui/imgui.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkPathBuilder.h"
 
 #include "flutter/display_list/display_list_builder.h"
+#include "flutter/display_list/types.h"
 #include "flutter/testing/testing.h"
 #include "impeller/display_list/display_list_image_impeller.h"
 #include "impeller/display_list/display_list_playground.h"
@@ -168,6 +171,27 @@ TEST_F(DisplayListTest, StrokedPathsDrawCorrectly) {
     path.lineTo({100, 0});
     path.lineTo({100, 0});
     builder.drawPath(path);
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_F(DisplayListTest, CanDrawWithMaskBlur) {
+  auto texture = CreateTextureForFixture("embarcadero.jpg");
+  flutter::DisplayListBuilder builder;
+
+  {
+    auto filter = flutter::DlBlurMaskFilter(kNormal_SkBlurStyle, 10.0f);
+    builder.setMaskFilter(&filter);
+    builder.drawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+                      SkSamplingOptions{}, true);
+  }
+
+  {
+    builder.setColor(SK_ColorYELLOW);
+    auto filter = flutter::DlBlurMaskFilter(kOuter_SkBlurStyle, 10.0f);
+    builder.setMaskFilter(&filter);
+    builder.drawArc(SkRect::MakeXYWH(410, 110, 100, 100), 45, 270, true);
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -180,6 +180,7 @@ TEST_F(DisplayListTest, CanDrawWithMaskBlur) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   flutter::DisplayListBuilder builder;
 
+  // Mask blurred image.
   {
     auto filter = flutter::DlBlurMaskFilter(kNormal_SkBlurStyle, 10.0f);
     builder.setMaskFilter(&filter);
@@ -187,11 +188,18 @@ TEST_F(DisplayListTest, CanDrawWithMaskBlur) {
                       SkSamplingOptions{}, true);
   }
 
+  // Mask blurred filled path.
   {
     builder.setColor(SK_ColorYELLOW);
     auto filter = flutter::DlBlurMaskFilter(kOuter_SkBlurStyle, 10.0f);
     builder.setMaskFilter(&filter);
     builder.drawArc(SkRect::MakeXYWH(410, 110, 100, 100), 45, 270, true);
+  }
+
+  // Mask blurred text.
+  {
+    builder.drawTextBlob(
+        SkTextBlob::MakeFromString("Testing", CreateTestFont()), 220, 170);
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -198,6 +198,8 @@ TEST_F(DisplayListTest, CanDrawWithMaskBlur) {
 
   // Mask blurred text.
   {
+    auto filter = flutter::DlBlurMaskFilter(kSolid_SkBlurStyle, 10.0f);
+    builder.setMaskFilter(&filter);
     builder.drawTextBlob(
         SkTextBlob::MakeFromString("Testing", CreateTestFont()), 220, 170);
   }

--- a/entity/contents/contents.cc
+++ b/entity/contents/contents.cc
@@ -47,7 +47,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
                                             RenderPass& pass) -> bool {
         Entity sub_entity;
         sub_entity.SetPath(entity.GetPath());
-        sub_entity.SetBlendMode(Entity::BlendMode::kSource);
+        sub_entity.SetBlendMode(Entity::BlendMode::kSourceOver);
         sub_entity.SetTransformation(
             Matrix::MakeTranslation(Vector3(-bounds->origin)) *
             entity.GetTransformation());


### PR DESCRIPTION
We have 2 methods for achieving mask blur behavior:
- For images, use the BorderMaskBlurFilter, which is constant time per-fragment.
- For solid color fills, do a Gaussian blur, which is linear per-fragment, but does two subpasses. See below for future optimization ideas.

Future optimizations:
- Do `BorderMaskBlur` directly in the parent pass. Depending on the entity context, rendering into a subpass is unnecessary. This could also be done for the second gaussian blur pass. This is a feature I've been thinking about adding to `FilterContents`.
- For solid fills, trade GPU memory/time for CPU time: For the arbitrary path case, generate inset/outset geometry and give them distance coordinates. This isn't trivial for concave paths segments, but off the top of my head, I can think of a tunable heuristic to do this path-size linearly. The tunable parameter would tradeoff CPU time (computing more geometry) with overlapping penumbra artifact size.

kOuter mask blurred solid path over a kNormal mask blurred image:
![Screen Shot 2022-04-18 at 2 24 03 PM](https://user-images.githubusercontent.com/919017/163880852-6ee4d40e-ef4f-4cd4-b447-11a1f1e0b7f6.png)
