### PR TITLE
Fix EntityPass/SaveLayer draw ordering

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -620,7 +620,31 @@ TEST_P(AiksTest, DrawRectStrokesRenderCorrectly) {
 
   canvas.Translate({100, 100});
   canvas.DrawPath(PathBuilder{}.AddRect(Rect::MakeSize({100, 100})).TakePath(),
-                  paint);
+                  {paint});
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, SaveLayerDrawsBehindSubsequentEntities) {
+  // Compare with https://fiddle.skia.org/c/9e03de8567ffb49e7e83f53b64bcf636
+  Canvas canvas;
+  Paint paint;
+
+  paint.color = Color::Black();
+  Rect rect(25, 25, 25, 25);
+  canvas.DrawRect(rect, paint);
+
+  canvas.Translate({10, 10});
+  canvas.SaveLayer({});
+
+  paint.color = Color::Green();
+  canvas.DrawRect(rect, paint);
+
+  canvas.Restore();
+
+  canvas.Translate({10, 10});
+  paint.color = Color::Red();
+  canvas.DrawRect(rect, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/entity/entity_pass.cc
+++ b/entity/entity_pass.cc
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 #include "impeller/entity/entity_pass.h"
+#include <variant>
 
+#include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
@@ -26,22 +28,20 @@ void EntityPass::SetDelegate(std::unique_ptr<EntityPassDelegate> delegate) {
 }
 
 void EntityPass::AddEntity(Entity entity) {
-  entities_.emplace_back(std::move(entity));
+  elements_.emplace_back(std::move(entity));
 }
 
-const std::vector<Entity>& EntityPass::GetEntities() const {
-  return entities_;
-}
-
-void EntityPass::SetEntities(Entities entities) {
-  entities_ = std::move(entities);
+void EntityPass::SetElements(std::vector<Element> elements) {
+  elements_ = std::move(elements);
 }
 
 size_t EntityPass::GetSubpassesDepth() const {
   size_t max_subpass_depth = 0u;
-  for (const auto& subpass : subpasses_) {
-    max_subpass_depth =
-        std::max(max_subpass_depth, subpass->GetSubpassesDepth());
+  for (const auto& element : elements_) {
+    if (auto subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      max_subpass_depth =
+          std::max(max_subpass_depth, subpass->get()->GetSubpassesDepth());
+    }
   }
   return max_subpass_depth + 1u;
 }
@@ -50,10 +50,20 @@ const std::shared_ptr<LazyGlyphAtlas>& EntityPass::GetLazyGlyphAtlas() const {
   return lazy_glyph_atlas_;
 }
 
-std::optional<Rect> EntityPass::GetEntitiesCoverage() const {
+std::optional<Rect> EntityPass::GetElementsCoverage() const {
   std::optional<Rect> result;
-  for (const auto& entity : entities_) {
-    auto coverage = entity.GetCoverage();
+  for (const auto& element : elements_) {
+    std::optional<Rect> coverage;
+
+    if (auto entity = std::get_if<Entity>(&element)) {
+      coverage = entity->GetCoverage();
+    } else if (auto subpass =
+                   std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      coverage = subpass->get()->GetElementsCoverage();
+    } else {
+      FML_UNREACHABLE();
+    }
+
     if (!result.has_value() && coverage.has_value()) {
       result = coverage;
       continue;
@@ -68,7 +78,7 @@ std::optional<Rect> EntityPass::GetEntitiesCoverage() const {
 
 std::optional<Rect> EntityPass::GetSubpassCoverage(
     const EntityPass& subpass) const {
-  auto entities_coverage = subpass.GetEntitiesCoverage();
+  auto entities_coverage = subpass.GetElementsCoverage();
   // The entities don't cover anything. There is nothing to do.
   if (!entities_coverage.has_value()) {
     return std::nullopt;
@@ -94,17 +104,15 @@ EntityPass* EntityPass::GetSuperpass() const {
   return superpass_;
 }
 
-const EntityPass::Subpasses& EntityPass::GetSubpasses() const {
-  return subpasses_;
-}
-
 EntityPass* EntityPass::AddSubpass(std::unique_ptr<EntityPass> pass) {
   if (!pass) {
     return nullptr;
   }
   FML_DCHECK(pass->superpass_ == nullptr);
   pass->superpass_ = this;
-  return subpasses_.emplace_back(std::move(pass)).get();
+  auto subpass_pointer = pass.get();
+  elements_.emplace_back(std::move(pass));
+  return subpass_pointer;
 }
 
 bool EntityPass::Render(ContentContext& renderer,
@@ -112,114 +120,133 @@ bool EntityPass::Render(ContentContext& renderer,
                         Point position) const {
   TRACE_EVENT0("impeller", "EntityPass::Render");
 
-  for (Entity entity : entities_) {
-    if (!position.IsZero()) {
-      // If the pass image is going to be rendered with a non-zero position,
-      // apply the negative translation to entity copies before rendering them
-      // so that they'll end up rendering to the correct on-screen position.
-      entity.SetTransformation(Matrix::MakeTranslation(Vector3(-position)) *
-                               entity.GetTransformation());
-    }
-    if (!entity.Render(renderer, parent_pass)) {
-      return false;
-    }
-  }
-
-  for (const auto& subpass : subpasses_) {
-    if (delegate_->CanElide()) {
-      continue;
-    }
-
-    if (delegate_->CanCollapseIntoParentPass()) {
-      // Directly render into the parent pass and move on.
-      if (!subpass->Render(renderer, parent_pass, position)) {
+  for (const auto& element : elements_) {
+    // =========================================================================
+    // Entity rendering ========================================================
+    // =========================================================================
+    if (const auto& entity = std::get_if<Entity>(&element)) {
+      Entity e = *entity;
+      if (!position.IsZero()) {
+        // If the pass image is going to be rendered with a non-zero position,
+        // apply the negative translation to entity copies before rendering them
+        // so that they'll end up rendering to the correct on-screen position.
+        e.SetTransformation(Matrix::MakeTranslation(Vector3(-position)) *
+                            e.GetTransformation());
+      }
+      if (!e.Render(renderer, parent_pass)) {
         return false;
       }
       continue;
     }
 
-    const auto subpass_coverage = GetSubpassCoverage(*subpass);
+    // =========================================================================
+    // Subpass rendering =======================================================
+    // =========================================================================
+    if (const auto& subpass_ptr =
+            std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      auto subpass = subpass_ptr->get();
 
-    if (!subpass_coverage.has_value()) {
+      if (delegate_->CanElide()) {
+        continue;
+      }
+
+      if (delegate_->CanCollapseIntoParentPass()) {
+        // Directly render into the parent pass and move on.
+        if (!subpass->Render(renderer, parent_pass, position)) {
+          return false;
+        }
+        continue;
+      }
+
+      const auto subpass_coverage = GetSubpassCoverage(*subpass);
+
+      if (!subpass_coverage.has_value()) {
+        continue;
+      }
+
+      if (subpass_coverage->size.IsEmpty()) {
+        // It is not an error to have an empty subpass. But subpasses that can't
+        // create their intermediates must trip errors.
+        continue;
+      }
+
+      auto context = renderer.GetContext();
+
+      auto subpass_target = RenderTarget::CreateOffscreen(
+          *context, ISize::Ceil(subpass_coverage->size));
+
+      auto subpass_texture = subpass_target.GetRenderTargetTexture();
+
+      if (!subpass_texture) {
+        return false;
+      }
+
+      auto offscreen_texture_contents =
+          delegate_->CreateContentsForSubpassTarget(subpass_texture);
+
+      if (!offscreen_texture_contents) {
+        // This is an error because the subpass delegate said the pass couldn't
+        // be collapsed into its parent. Yet, when asked how it want's to
+        // postprocess the offscreen texture, it couldn't give us an answer.
+        //
+        // Theoretically, we could collapse the pass now. But that would be
+        // wasteful as we already have the offscreen texture and we don't want
+        // to discard it without ever using it. Just make the delegate do the
+        // right thing.
+        return false;
+      }
+
+      auto sub_command_buffer = context->CreateRenderCommandBuffer();
+
+      sub_command_buffer->SetLabel("Offscreen Command Buffer");
+
+      if (!sub_command_buffer) {
+        return false;
+      }
+
+      auto sub_renderpass =
+          sub_command_buffer->CreateRenderPass(subpass_target);
+
+      if (!sub_renderpass) {
+        return false;
+      }
+
+      sub_renderpass->SetLabel("OffscreenPass");
+
+      if (!subpass->Render(renderer, *sub_renderpass,
+                           subpass_coverage->origin)) {
+        return false;
+      }
+
+      if (!sub_renderpass->EncodeCommands(*context->GetTransientsAllocator())) {
+        return false;
+      }
+
+      if (!sub_command_buffer->SubmitCommands()) {
+        return false;
+      }
+
+      Entity entity;
+      entity.SetPath(PathBuilder{}
+                         .AddRect(Rect::MakeSize(subpass_coverage->size))
+                         .TakePath());
+      entity.SetContents(std::move(offscreen_texture_contents));
+      entity.SetStencilDepth(stencil_depth_);
+      entity.SetBlendMode(subpass->blend_mode_);
+      // Once we have filters being applied for SaveLayer, some special sauce
+      // may be needed here (or in PaintPassDelegate) to ensure the filter
+      // parameters are transformed by the `xformation_` matrix, while
+      // continuing to apply only the subpass offset to the offscreen texture.
+      entity.SetTransformation(Matrix::MakeTranslation(
+          Vector3(subpass_coverage->origin - position)));
+      if (!entity.Render(renderer, parent_pass)) {
+        return false;
+      }
+
       continue;
     }
 
-    if (subpass_coverage->size.IsEmpty()) {
-      // It is not an error to have an empty subpass. But subpasses that can't
-      // create their intermediates must trip errors.
-      continue;
-    }
-
-    auto context = renderer.GetContext();
-
-    auto subpass_target = RenderTarget::CreateOffscreen(
-        *context, ISize::Ceil(subpass_coverage->size));
-
-    auto subpass_texture = subpass_target.GetRenderTargetTexture();
-
-    if (!subpass_texture) {
-      return false;
-    }
-
-    auto offscreen_texture_contents =
-        delegate_->CreateContentsForSubpassTarget(subpass_texture);
-
-    if (!offscreen_texture_contents) {
-      // This is an error because the subpass delegate said the pass couldn't be
-      // collapsed into its parent. Yet, when asked how it want's to postprocess
-      // the offscreen texture, it couldn't give us an answer.
-      //
-      // Theoretically, we could collapse the pass now. But that would be
-      // wasteful as we already have the offscreen texture and we don't want to
-      // discard it without ever using it. Just make the delegate do the right
-      // thing.
-      return false;
-    }
-
-    auto sub_command_buffer = context->CreateRenderCommandBuffer();
-
-    sub_command_buffer->SetLabel("Offscreen Command Buffer");
-
-    if (!sub_command_buffer) {
-      return false;
-    }
-
-    auto sub_renderpass = sub_command_buffer->CreateRenderPass(subpass_target);
-
-    if (!sub_renderpass) {
-      return false;
-    }
-
-    sub_renderpass->SetLabel("OffscreenPass");
-
-    if (!subpass->Render(renderer, *sub_renderpass, subpass_coverage->origin)) {
-      return false;
-    }
-
-    if (!sub_renderpass->EncodeCommands(*context->GetTransientsAllocator())) {
-      return false;
-    }
-
-    if (!sub_command_buffer->SubmitCommands()) {
-      return false;
-    }
-
-    Entity entity;
-    entity.SetPath(PathBuilder{}
-                       .AddRect(Rect::MakeSize(subpass_coverage->size))
-                       .TakePath());
-    entity.SetContents(std::move(offscreen_texture_contents));
-    entity.SetStencilDepth(stencil_depth_);
-    entity.SetBlendMode(subpass->blend_mode_);
-    // Once we have filters being applied for SaveLayer, some special sauce
-    // may be needed here (or in PaintPassDelegate) to ensure the filter
-    // parameters are transformed by the `xformation_` matrix, while continuing
-    // to apply only the subpass offset to the offscreen texture.
-    entity.SetTransformation(
-        Matrix::MakeTranslation(Vector3(subpass_coverage->origin - position)));
-    if (!entity.Render(renderer, parent_pass)) {
-      return false;
-    }
+    FML_UNREACHABLE();
   }
 
   return true;
@@ -230,23 +257,39 @@ void EntityPass::IterateAllEntities(std::function<bool(Entity&)> iterator) {
     return;
   }
 
-  for (auto& entity : entities_) {
-    if (!iterator(entity)) {
-      return;
+  for (auto& element : elements_) {
+    if (auto entity = std::get_if<Entity>(&element)) {
+      if (!iterator(*entity)) {
+        return;
+      }
+      continue;
     }
-  }
-
-  for (auto& subpass : subpasses_) {
-    subpass->IterateAllEntities(iterator);
+    if (auto subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      subpass->get()->IterateAllEntities(iterator);
+      continue;
+    }
+    FML_UNREACHABLE();
   }
 }
 
 std::unique_ptr<EntityPass> EntityPass::Clone() const {
-  auto pass = std::make_unique<EntityPass>();
-  pass->SetEntities(entities_);
-  for (const auto& subpass : subpasses_) {
-    pass->AddSubpass(subpass->Clone());
+  std::vector<Element> new_elements;
+  new_elements.reserve(elements_.size());
+
+  for (const auto& element : elements_) {
+    if (auto entity = std::get_if<Entity>(&element)) {
+      new_elements.push_back(*entity);
+      continue;
+    }
+    if (auto subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      new_elements.push_back(subpass->get()->Clone());
+      continue;
+    }
+    FML_UNREACHABLE();
   }
+
+  auto pass = std::make_unique<EntityPass>();
+  pass->SetElements(std::move(new_elements));
   return pass;
 }
 

--- a/entity/entity_pass.h
+++ b/entity/entity_pass.h
@@ -21,8 +21,7 @@ class ContentContext;
 
 class EntityPass {
  public:
-  using Entities = std::vector<Entity>;
-  using Subpasses = std::vector<std::unique_ptr<EntityPass>>;
+  using Element = std::variant<Entity, std::unique_ptr<EntityPass>>;
 
   EntityPass();
 
@@ -36,11 +35,7 @@ class EntityPass {
 
   void AddEntity(Entity entity);
 
-  void SetEntities(Entities entities);
-
-  const std::vector<Entity>& GetEntities() const;
-
-  const Subpasses& GetSubpasses() const;
+  void SetElements(std::vector<Element> elements);
 
   const std::shared_ptr<LazyGlyphAtlas>& GetLazyGlyphAtlas() const;
 
@@ -61,8 +56,8 @@ class EntityPass {
   void SetBlendMode(Entity::BlendMode blend_mode);
 
  private:
-  Entities entities_;
-  Subpasses subpasses_;
+  std::vector<Element> elements_;
+
   EntityPass* superpass_ = nullptr;
   Matrix xformation_;
   size_t stencil_depth_ = 0u;
@@ -74,7 +69,7 @@ class EntityPass {
 
   std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
 
-  std::optional<Rect> GetEntitiesCoverage() const;
+  std::optional<Rect> GetElementsCoverage() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPass);
 };


### PR DESCRIPTION
Interleave Entities and Subpasses in `EntityPass`. Before this change, all subpasses would draw over all entities for the pass.

Minimal repro:
```
impeller_unittests --gtest_filter=Play/AiksTest.SaveLayerDrawsBehindSubsequentEntities/Metal --timeout=0
```
Skia fiddle: https://fiddle.skia.org/c/9e03de8567ffb49e7e83f53b64bcf636

Before:

![Screen Shot 2022-04-18 at 6 11 03 PM](https://user-images.githubusercontent.com/919017/163900505-6500fa4d-543a-4096-a888-b086ea503104.png)

After:

![Screen Shot 2022-04-18 at 6 09 12 PM](https://user-images.githubusercontent.com/919017/163900366-3e111ea3-d6b0-4887-b023-d7b8b7821e35.png)

