### PR TITLE
Fix border mask blur cutoff

### DIFF
--- a/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -92,9 +92,7 @@ bool BorderMaskBlurFilterContents::RenderFilter(
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-  auto scale = entity.GetTransformation().GetScale();
-  frame_info.sigma_uv = Vector2(scale.x, scale.y) *
-                        Vector2(sigma_x_.sigma, sigma_y_.sigma).Abs() /
+  frame_info.sigma_uv = Vector2(sigma_x_.sigma, sigma_y_.sigma).Abs() /
                         input_snapshot->texture->GetSize();
   frame_info.src_factor = src_color_factor_;
   frame_info.inner_blur_factor = inner_blur_factor_;

--- a/entity/shaders/border_mask_blur.frag
+++ b/entity/shaders/border_mask_blur.frag
@@ -33,7 +33,10 @@ const float kHalfSqrtTwo = 0.70710678118;
 
 // Indefinite integral of the Gaussian function (with constant range 0->1).
 float GaussianIntegral(float x, float sigma) {
-  return 0.5 + 0.5 * erf(x * (kHalfSqrtTwo / sigma));
+  // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
+  // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
+  // so that it always fades to zero before it reaches the blur radius.
+  return 0.535 * erf(x * (kHalfSqrtTwo / sigma)) + 0.465;
 }
 
 float BoxBlurMask(vec2 uv) {


### PR DESCRIPTION
This fixes a couple of issues I just noticed in the border mask blur.

1. Fix double-scaling problem with the sigma parameter. We use the inverse mapped "coverage UVs" of the input snapshot as the "border" in the border mask blur. Since we apply the mask blur over the UV space, it already takes into account the full transform, so I shouldn't have added that second scale in.
2. Slightly [scale and shift](https://www.desmos.com/calculator/xugr5njftx) the Gaussian integral such that it always has a root pretty close to the border radius, which makes the cutoff sloped, but not sudden.

Before (case where both issues are contributing to the badness):
![Screen Shot 2022-04-21 at 2 31 07 AM](https://user-images.githubusercontent.com/919017/164425896-31b52056-53cf-4320-aa23-22e1a8f1bb91.png)

After:
![Screen Shot 2022-04-21 at 2 32 16 AM](https://user-images.githubusercontent.com/919017/164425986-019b86f2-883b-40d8-a4a5-c31217a2c01f.png)

