### PR TITLE
Remove dependency on Dart, add crash handler to impellerc

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -55,10 +55,6 @@ executable("impeller_unittests") {
     "blobcat:blobcat_unittests",
     "compiler:compiler_unittests",
     "geometry:geometry_unittests",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
   ]
 
   if (impeller_supports_rendering) {

--- a/blobcat/BUILD.gn
+++ b/blobcat/BUILD.gn
@@ -29,10 +29,6 @@ impeller_component("blobcat") {
     ":blobcat_lib",
     "../base",
     "//flutter/fml",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
   ]
 }
 

--- a/compiler/BUILD.gn
+++ b/compiler/BUILD.gn
@@ -44,10 +44,6 @@ impeller_component("impellerc") {
 
   deps = [
     ":compiler_lib",
-
-    # FML depends on the Dart VM for tracing and getting the current
-    # timepoint.
-    "//flutter/runtime:libdart",
   ]
 }
 

--- a/compiler/impellerc_main.cc
+++ b/compiler/impellerc_main.cc
@@ -4,6 +4,7 @@
 
 #include <filesystem>
 
+#include "flutter/fml/backtrace.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/macros.h"
@@ -18,6 +19,7 @@ namespace impeller {
 namespace compiler {
 
 bool Main(const fml::CommandLine& command_line) {
+  fml::InstallCrashHandler();
   if (command_line.HasOption("help")) {
     Switches::PrintHelp(std::cout);
     return true;


### PR DESCRIPTION
Depends on https://github.com/flutter/engine/pull/32846

Fixes https://github.com/flutter/flutter/issues/101866

Added the crash handler because at one point changes in the engine I made caused impellerc to segfault and I had no idea why :)