### PR TITLE
Revert "Use New DlPathEffect Object"

### DIFF
--- a/display_list/display_list_dispatcher.cc
+++ b/display_list/display_list_dispatcher.cc
@@ -249,7 +249,7 @@ void DisplayListDispatcher::setBlender(sk_sp<SkBlender> blender) {
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::setPathEffect(const flutter::DlPathEffect* effect) {
+void DisplayListDispatcher::setPathEffect(sk_sp<SkPathEffect> effect) {
   // Needs https://github.com/flutter/flutter/issues/95434
   UNIMPLEMENTED;
 }

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -61,7 +61,7 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void setBlender(sk_sp<SkBlender> blender) override;
 
   // |flutter::Dispatcher|
-  void setPathEffect(const flutter::DlPathEffect* effect) override;
+  void setPathEffect(sk_sp<SkPathEffect> effect) override;
 
   // |flutter::Dispatcher|
   void setMaskFilter(const flutter::DlMaskFilter* filter) override;


### PR DESCRIPTION
Reverts flutter/impeller#98

This was pushed before the developer was ready to push the associated engine PR. It will be easy enough to reland when they (are ready to) rebase their PR.

Apologies @JsouLiang 