### PR TITLE
Another coverage fix for border mask blur

### DIFF
--- a/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -117,13 +117,10 @@ std::optional<Rect> BorderMaskBlurFilterContents::GetFilterCoverage(
   if (!coverage.has_value()) {
     return std::nullopt;
   }
-
+  auto transform = inputs[0]->GetTransform(entity);
   auto transformed_blur_vector =
-      inputs[0]
-          ->GetTransform(entity)
-          .TransformDirection(
-              Vector2(Radius{sigma_x_}.radius, Radius{sigma_y_}.radius))
-          .Abs();
+      transform.TransformDirection(Vector2(Radius{sigma_x_}.radius, 0)).Abs() +
+      transform.TransformDirection(Vector2(0, Radius{sigma_y_}.radius)).Abs();
   auto extent = coverage->size + transformed_blur_vector * 2;
   return Rect(coverage->origin - transformed_blur_vector,
               Size(extent.x, extent.y));


### PR DESCRIPTION
I noticed in passing that for some rotations, the corners were getting a bit cut off for some rotations. For example: At 45 degrees, the X axis of `transformed_blur_vector` was zero, even though it should be at its greatest length here (`sqrt((x + y)^2)`).

The incorrect version makes a diagonal vector from the input radii and rotates it by the basis matrix (which of course winds up being x=0 at 45 degrees). The corrected version takes the absolute value of each rotated axis _before_ adding them rather than after.