### PR TITLE
WIP: Render non-pipeline blend modes

### DIFF
--- a/aiks/aiks_unittests.cc
+++ b/aiks/aiks_unittests.cc
@@ -467,6 +467,25 @@ TEST_P(AiksTest, PaintBlendModeIsRespected) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanDrawWithAdvancedBlend) {
+  Paint paint;
+  Canvas canvas;
+  // Default is kSourceOver.
+  paint.color = Color(1, 0, 0, 0.5);
+  canvas.DrawCircle(Point(150, 200), 100, paint);
+  paint.color = Color(0, 1, 0, 0.5);
+  canvas.DrawCircle(Point(250, 200), 100, paint);
+
+  paint.blend_mode = Entity::BlendMode::kScreen;
+  //paint.color = Color::Red();
+  //canvas.DrawCircle(Point(450, 250), 100, paint);
+  paint.color = Color::Green();
+  canvas.DrawCircle(Point(550, 250), 100, paint);
+  paint.color = Color::Blue();
+  canvas.DrawCircle(Point(500, 150), 100, paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, TransformMultipliesCorrectly) {
   Canvas canvas;
   ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(), Matrix());

--- a/entity/contents/content_context.cc
+++ b/entity/contents/content_context.cc
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
 

--- a/entity/contents/filters/filter_contents.cc
+++ b/entity/contents/filters/filter_contents.cc
@@ -16,7 +16,6 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/filters/blend_filter_contents.h"
 #include "impeller/entity/contents/filters/border_mask_blur_filter_contents.h"
-#include "impeller/entity/contents/filters/inputs/filter_input.h"
 #include "impeller/entity/contents/filters/gaussian_blur_filter_contents.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/entity.h"

--- a/entity/contents/filters/inputs/texture_filter_input.cc
+++ b/entity/contents/filters/inputs/texture_filter_input.cc
@@ -27,9 +27,4 @@ std::optional<Rect> TextureFilterInput::GetCoverage(
       .TransformBounds(GetTransform(entity));
 }
 
-Matrix TextureFilterInput::GetLocalTransform(const Entity& entity) const {
-  // Compute the local transform such that the texture is centered.
-  return Matrix::MakeTranslation(-Point(texture_->GetSize()) / 2);
-}
-
 }  // namespace impeller

--- a/entity/contents/filters/inputs/texture_filter_input.h
+++ b/entity/contents/filters/inputs/texture_filter_input.h
@@ -22,9 +22,6 @@ class TextureFilterInput final : public FilterInput {
   // |FilterInput|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
-  // |FilterInput|
-  Matrix GetLocalTransform(const Entity& entity) const override;
-
  private:
   TextureFilterInput(std::shared_ptr<Texture> texture);
 

--- a/entity/entity_unittests.cc
+++ b/entity/entity_unittests.cc
@@ -747,14 +747,16 @@ TEST_P(EntityTest, GaussianBlurFilter) {
         blur_styles[selected_blur_style]);
 
     auto mask_blur = FilterContents::MakeBorderMaskBlur(
-        FilterInput::Make(boston), FilterContents::Sigma{blur_amount[0]},
+        FilterInput::Make(bridge), FilterContents::Sigma{blur_amount[0]},
         FilterContents::Sigma{blur_amount[1]},
         blur_styles[selected_blur_style]);
 
+    auto input_size = bridge->GetSize();
     auto ctm = Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *
                Matrix::MakeRotationZ(Radians(rotation)) *
                Matrix::MakeScale(Vector2(scale[0], scale[1])) *
-               Matrix::MakeSkew(skew[0], skew[1]);
+               Matrix::MakeSkew(skew[0], skew[1]) *
+               Matrix::MakeTranslation(-Point(input_size) / 2);
 
     auto target_contents = selected_blur_type == 0 ? blur : mask_blur;
 
@@ -768,10 +770,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     // unfiltered input.
     Entity cover_entity;
     cover_entity.SetContents(SolidColorContents::Make(
-        PathBuilder{}
-            .AddRect(
-                Rect(-Point(bridge->GetSize()) / 2, Size(bridge->GetSize())))
-            .TakePath(),
+        PathBuilder{}.AddRect(Rect::MakeSize(Size(input_size))).TakePath(),
         cover_color));
     cover_entity.SetTransformation(ctm);
 

--- a/entity/shaders/texture_blend_screen.frag
+++ b/entity/shaders/texture_blend_screen.frag
@@ -18,8 +18,10 @@ vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
   return vec4(0);
 }
 
+
 void main() {
-  vec4 dst = SampleWithBorder(texture_sampler_dst, v_dst_texture_coords);
+  vec4 dst = texture(texture_sampler_dst, v_dst_texture_coords);
   vec4 src = SampleWithBorder(texture_sampler_src, v_src_texture_coords);
   frag_color = src + dst - src * dst;
+  frag_color = dst;
 }

--- a/renderer/backend/metal/surface_mtl.mm
+++ b/renderer/backend/metal/surface_mtl.mm
@@ -46,7 +46,8 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   color0_tex_desc.size = {
       static_cast<ISize::Type>(current_drawable.texture.width),
       static_cast<ISize::Type>(current_drawable.texture.height)};
-  color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+  color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
+                          static_cast<uint64_t>(TextureUsage::kShaderRead);
 
   auto msaa_tex = context->GetPermanentsAllocator()->CreateTexture(
       StorageMode::kDeviceTransient, color0_tex_desc);
@@ -61,7 +62,8 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   color0_resolve_tex_desc.format = color_format;
   color0_resolve_tex_desc.size = color0_tex_desc.size;
   color0_resolve_tex_desc.usage =
-      static_cast<uint64_t>(TextureUsage::kRenderTarget);
+      static_cast<uint64_t>(TextureUsage::kRenderTarget) |
+      static_cast<uint64_t>(TextureUsage::kShaderRead);
 
   ColorAttachment color0;
   color0.texture = msaa_tex;


### PR DESCRIPTION
Attach blend filters on the fly to support rendering with "advanced" (non-pipeline) blend modes. Advanced blends manipulate color, and behave like kSourceOver alpha-wise. They require sampling the source/destination textures as inputs and rendering to an intermediate texture, whereas the "pipeline" blends are simple Porter-Duff alpha blends blend that can be covered by fragment blend options.

This isn't quite working yet because there isn't a way to read multisample textures in Impeller shaders right now:
1. GLSL 4+ removes the `texture(sampler2DMS, vec2)` overload.
2. `texelFetch` can't be used with GLES2.
