### PR TITLE
Avoid instancing/SSBOs for text to support GLES

### DIFF
--- a/entity/shaders/glyph_atlas.vert
+++ b/entity/shaders/glyph_atlas.vert
@@ -2,37 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifdef IMPELLER_TARGET_OPENGLES
-
-void main() {
-  // Unimplemented because the implementation uses instancing and SSBOs.
-}
-
-#else  // IMPELLER_TARGET_OPENGLES
-
 uniform FrameInfo {
   mat4 mvp;
   vec2 atlas_size;
   vec4 text_color;
 } frame_info;
 
-readonly buffer GlyphPositions {
-  mat4 position[];
-} glyph_positions;
-
-readonly buffer GlyphSizes {
-  vec2 size[];
-} glyph_sizes;
-
-readonly buffer AtlasPositions {
-  vec2 position[];
-} atlas_positions;
-
-readonly buffer AtlasGlyphSizes {
-  vec2 size[];
-} atlas_glyph_sizes;
-
 in vec2 unit_vertex;
+in vec2 glyph_position;
+in vec2 glyph_size;
+in vec2 atlas_position;
+in vec2 atlas_glyph_size;
 
 out vec2 v_unit_vertex;
 out vec2 v_atlas_position;
@@ -41,26 +21,25 @@ out vec2 v_atlas_size;
 out vec4 v_text_color;
 
 void main() {
-  // The position to place the glyph.
-  mat4 glyph_position = glyph_positions.position[gl_InstanceIndex];
-  // The size of the glyph.
-  vec2 glyph_size = glyph_sizes.size[gl_InstanceIndex];
-  // The location of the glyph in the atlas.
-  vec2 glyph_atlas_position = atlas_positions.position[gl_InstanceIndex];
-  // The size of the glyph within the atlas.
-  vec2 glyph_atlas_size = atlas_glyph_sizes.size[gl_InstanceIndex];
-
-  gl_Position = frame_info.mvp
-              * glyph_position
+  vec4 translate = frame_info.mvp[0] * glyph_position.x
+                 + frame_info.mvp[1] * glyph_position.y
+                 + frame_info.mvp[3];
+  mat4 translated_mvp = mat4(
+    frame_info.mvp[0],
+    frame_info.mvp[1],
+    frame_info.mvp[2],
+    vec4(
+      translate.xyz,
+      frame_info.mvp[3].w
+    )
+  );
+  gl_Position = translated_mvp
               * vec4(unit_vertex.x * glyph_size.x,
                      unit_vertex.y * glyph_size.y, 0.0, 1.0);
 
   v_unit_vertex = unit_vertex;
-  v_atlas_position = glyph_atlas_position;
-  v_atlas_glyph_size = glyph_atlas_size;
+  v_atlas_position = atlas_position;
+  v_atlas_glyph_size = atlas_glyph_size;
   v_atlas_size = frame_info.atlas_size;
   v_text_color = frame_info.text_color;
 }
-
-#endif  // IMPELLER_TARGET_OPENGLES
-

--- a/typographer/backends/skia/text_frame_skia.cc
+++ b/typographer/backends/skia/text_frame_skia.cc
@@ -52,8 +52,7 @@ TextFrame TextFrameFromTextBlob(sk_sp<SkTextBlob> blob, Scalar scale) {
           // kFull_Positioning has two scalars per glyph.
           const SkPoint* glyph_points = run.points();
           const auto* point = glyph_points + i;
-          text_run.AddGlyph(glyphs[i],
-                            Matrix::MakeTranslation({point->x(), point->y()}));
+          text_run.AddGlyph(glyphs[i], Point{point->x(), point->y()});
         }
         break;
       case SkTextBlobRunIterator::kRSXform_Positioning:

--- a/typographer/text_frame.cc
+++ b/typographer/text_frame.cc
@@ -16,8 +16,8 @@ std::optional<Rect> TextFrame::GetBounds() const {
   for (const auto& run : runs_) {
     const auto glyph_bounds = run.GetFont().GetMetrics().GetBoundingBox();
     for (const auto& glyph_position : run.GetGlyphPositions()) {
-      Vector2 position = glyph_position.position * Vector2();
-      Rect glyph_rect = Rect(position + glyph_bounds.origin, glyph_bounds.size);
+      Rect glyph_rect = Rect(glyph_position.position + glyph_bounds.origin,
+                             glyph_bounds.size);
       result = result.has_value() ? result->Union(glyph_rect) : glyph_rect;
     }
   }

--- a/typographer/text_run.cc
+++ b/typographer/text_run.cc
@@ -15,7 +15,7 @@ TextRun::TextRun(Font font) : font_(std::move(font)) {
 
 TextRun::~TextRun() = default;
 
-bool TextRun::AddGlyph(Glyph glyph, Matrix position) {
+bool TextRun::AddGlyph(Glyph glyph, Point position) {
   glyphs_.emplace_back(GlyphPosition{glyph, position});
   return true;
 }

--- a/typographer/text_run.h
+++ b/typographer/text_run.h
@@ -20,9 +20,9 @@ class TextRun {
  public:
   struct GlyphPosition {
     Glyph glyph;
-    Matrix position;
+    Point position;
 
-    GlyphPosition(Glyph p_glyph, Matrix p_position)
+    GlyphPosition(Glyph p_glyph, Point p_position)
         : glyph(p_glyph), position(p_position) {}
   };
 
@@ -45,7 +45,7 @@ class TextRun {
   ///
   /// @return     If the glyph could be added to the run.
   ///
-  bool AddGlyph(Glyph glyph, Matrix position);
+  bool AddGlyph(Glyph glyph, Point position);
 
   //----------------------------------------------------------------------------
   /// @brief      Get the number of glyphs in the run.


### PR DESCRIPTION
Makes the glyph_atlas.vert compile for GLES.

Does the following:

- Converts the SSBOs to per vertex data params
- Refactors GlyphPosition to use just a Point instead of a full matrix. Skia does support RSXform which would be 4 scalars, but AFAICT Flutter doesn't expose a way to use this today. If we need it someday we can support it, but we should not need a full matrix to do that (we can just use a vec4).
- Does not use the tessellator for the unit vector tessellation, instead just has a pre-built vertex array for it.

There are no new tests for this, just that the compiler now produces valid GLES shaders and removes some defines no-opping text for GLES.