### PR TITLE
Make it an error for a stage input to take more than one slot.

### DIFF
--- a/compiler/compiler_unittests.cc
+++ b/compiler/compiler_unittests.cc
@@ -24,6 +24,14 @@ TEST_P(CompilerTest, CanCompile) {
   ASSERT_TRUE(CanCompileAndReflect("sample.vert"));
 }
 
+TEST_P(CompilerTest, MustFailDueToMultipleLocationPerStructMember) {
+  if (GetParam() == TargetPlatform::kFlutterSPIRV) {
+    // This is a failure of reflection which this target doesn't perform.
+    GTEST_SKIP();
+  }
+  ASSERT_FALSE(CanCompileAndReflect("struct_def_bug.vert"));
+}
+
 #define INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(suite_name)              \
   INSTANTIATE_TEST_SUITE_P(                                               \
       suite_name, CompilerTest,                                           \

--- a/fixtures/BUILD.gn
+++ b/fixtures/BUILD.gn
@@ -27,6 +27,7 @@ test_fixtures("file_fixtures") {
     "embarcadero.jpg",
     "kalimba.jpg",
     "sample.vert",
+    "struct_def_bug.vert",
     "types.h",
     "test_texture.frag",
     "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf",

--- a/fixtures/struct_def_bug.vert
+++ b/fixtures/struct_def_bug.vert
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FrameInfo {
+  mat4 mvp;
+  vec2 atlas_size;
+  vec4 text_color;
+} frame_info;
+
+in vec2 unit_vertex;
+in mat4 glyph_position; // <--- Causes multiple slots to be used and is a failure.
+in vec2 glyph_size;
+in vec2 atlas_position;
+in vec2 atlas_glyph_size;
+
+out vec2 v_unit_vertex;
+out vec2 v_atlas_position;
+out vec2 v_atlas_glyph_size;
+out vec2 v_atlas_size;
+out vec4 v_text_color;
+
+void main() {
+  gl_Position = frame_info.mvp
+              * glyph_position
+              * vec4(unit_vertex.x * glyph_size.x,
+                     unit_vertex.y * glyph_size.y, 0.0, 1.0);
+
+  v_unit_vertex = unit_vertex;
+  v_atlas_position = atlas_position;
+  v_atlas_glyph_size = atlas_glyph_size;
+  v_atlas_size = frame_info.atlas_size;
+  v_text_color = frame_info.text_color;
+}


### PR DESCRIPTION
Earlier, no PerVertexData struct would be generated. The shader is
useless without reflection information.

Fixes https://github.com/flutter/flutter/issues/102521.